### PR TITLE
Update Containerfile which tries to use the nonexisting requirements.txt file

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -31,9 +31,9 @@ COPY --from=lightspeed-rag-content /rag/embeddings_model ./embeddings_model
 
 # Add explicit files and directories
 # (avoid accidental inclusion of local directories or env files or credentials)
-COPY runner.py requirements.txt ./
+COPY runner.py pyproject.toml LICENSE README.md ./
 
-RUN pip3.11 install --no-cache-dir -r requirements.txt
+RUN pip3.11 install .
 
 COPY ols ./ols
 


### PR DESCRIPTION
## Description

This PR fixes the side effect of https://github.com/road-core/service/pull/66 where the requirements.txt file is deleted.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
For testing, just try to build the app image and validate if it works. I was able to test this in the fork project ansible/ansible-chatbot-service