### PR TITLE
Options to suppress Prometheus metrics and auth checks warnings in log

### DIFF
--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -68,6 +68,8 @@ ols_config:
     app_log_level: info
     lib_log_level: warning
     uvicorn_log_level: info
+    suppress_metrics_in_log: false
+    suppress_auth_checks_warning_in_log: false
   default_provider: my_bam
   default_model: ibm/granite-13b-chat-v2
   # query_filters:

--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -74,8 +74,12 @@ async def log_requests_responses(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
     """Middleware for logging of HTTP requests and responses, at debug level."""
-    # Bail out early if not logging
-    if not logger.isEnabledFor(logging.DEBUG):
+    # Bail out early if not logging or Prometheus metrics logging is suppressed
+    if (
+        not logger.isEnabledFor(logging.DEBUG)
+        or config.ols_config.logging_config.suppress_metrics_in_log
+        and request.url.path == "/metrics"
+    ):
         return await call_next(request)
 
     # retrieve client host and port if provided in request object

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -854,12 +854,14 @@ class LoggingConfig(BaseModel):
     app_log_level: int = logging.INFO
     lib_log_level: int = logging.WARNING
     uvicorn_log_level: int = logging.WARNING
+    suppress_metrics_in_log: bool = False
+    suppress_auth_checks_warning_in_log: bool = False
 
     def __init__(self, **data: Optional[dict]) -> None:
         """Initialize configuration and perform basic validation."""
         # convert input strings (level names, eg. debug/info,...) to
         # logging level names (integer values) for defined model fields
-        for field in self.model_fields:
+        for field in filter(lambda x: x.endswith("_log_level"), self.model_fields):
             if field in data:
                 data[field] = _get_log_level(data[field])  # type: ignore[assignment]
         super().__init__(**data)

--- a/ols/src/auth/k8s.py
+++ b/ols/src/auth/k8s.py
@@ -243,7 +243,11 @@ class AuthDependency(AuthDependencyInterface):
             HTTPException: If authentication fails or the user does not have access.
         """
         if config.dev_config.disable_auth:
-            logger.warning("Auth checks disabled, skipping")
+            if (
+                config.ols_config.logging_config is None
+                or not config.ols_config.logging_config.suppress_auth_checks_warning_in_log
+            ):
+                logger.warning("Auth checks disabled, skipping")
             # Use constant user ID and user name in case auth. is disabled
             # It will be needed for testing purposes because (for example)
             # conversation history and user feedback depend on having any

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -1408,6 +1408,8 @@ def test_valid_values():
     assert logging_config.app_log_level == logging.INFO
     assert logging_config.lib_log_level == logging.WARNING
     assert logging_config.uvicorn_log_level == logging.WARNING
+    assert not logging_config.suppress_metrics_in_log
+    assert not logging_config.suppress_auth_checks_warning_in_log
 
     # test custom values
     logging_config = LoggingConfig(


### PR DESCRIPTION
## Description
Provide options to Prometheus metrics and auth checks warnings in log. They are:

- `suppress_metrics_in_log` When this option is set to `true`, the output from `/metrics` are not sent to the log even if `app_log_level` is set to `debug`. Default is `false`.
- `suppress_auth_checks_warning_in_log` When this option is set to `true`, the `Auth checks disabled, skipping` warning message is suppressed on the log. Default is `false`

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
  Unit and integration test cases are provided.
 
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
  Run the service and check the log output with setting each option to `true`.