### PR TITLE
Option to let the LLM ready status get expired

### DIFF
--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -72,6 +72,7 @@ ols_config:
     suppress_auth_checks_warning_in_log: false
   default_provider: my_bam
   default_model: ibm/granite-13b-chat-v2
+  expire_llm_is_ready_persistent_state: -1
   # query_filters:
   #   - name: foo_filter
   #     pattern: '\b(?:foo)\b'

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -949,6 +949,7 @@ class OLSConfig(BaseModel):
 
     default_provider: Optional[str] = None
     default_model: Optional[str] = None
+    expire_llm_is_ready_persistent_state: Optional[int] = -1
     max_workers: Optional[int] = None
     query_filters: Optional[list[QueryFilter]] = None
     query_validation_method: Optional[str] = constants.QueryValidationMethod.DISABLED


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add a new option `expire_llm_is_ready_persistent_state` to specify the expiration time to let the "LLM Ready" status, which is used in the response of `/readiness` API, in seconds. The default is `-1` (= never expires). If the expiration occurs, the next `/readiness` API call will make a call against LLM again to check the status of LLM.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # [AAP-35769](https://issues.redhat.com/browse/AAP-35769)
- Closes # [AAP-35769](https://issues.redhat.com/browse/AAP-35769)

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
  Two new unit test cases are included in this PR.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.
  Set `expire_llm_is_ready_persistent_state` to a small value, like `10` secs, call `/readiness` API, wait long enough and then make the second `readiness` API call to check LLM log to verify the API called the LLM as expected. 
