### PR TITLE
Enable flake8 logger linter on CI

### DIFF
--- a/ols/utils/pyroscope.py
+++ b/ols/utils/pyroscope.py
@@ -19,7 +19,7 @@ def start_with_pyroscope_enabled(
         response = requests.get(config.dev_config.pyroscope_url, timeout=60)
         if response.status_code == requests.codes.ok:
             logger.info(
-                f"Pyroscope server is reachable at {config.dev_config.pyroscope_url}"
+                "Pyroscope server is reachable at %s", config.dev_config.pyroscope_url
             )
             import pyroscope
 
@@ -39,7 +39,8 @@ def start_with_pyroscope_enabled(
                 start_uvicorn(config)
         else:
             logger.info(
-                f"Failed to reach Pyroscope server. Status code: {response.status_code}"
+                "Failed to reach Pyroscope server. Status code: %d",
+                response.status_code,
             )
     except requests.exceptions.RequestException as e:
-        logger.info(f"Error connecting to Pyroscope server: {e}")
+        logger.info("Error connecting to Pyroscope server: %s", str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 
 # description of all rules are available on https://docs.astral.sh/ruff/rules/
-lint.select = ["D", "E", "F", "W", "C", "S", "I", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "A", "C4", "T10", "PGH", "FURB", "PERF", "AIR", "NPY", "FLY", "PLW2901"]
+lint.select = ["D", "E", "F", "W", "C", "S", "I", "G", "TCH", "SLOT", "RUF", "C90", "N", "YTT", "ASYNC", "A", "C4", "T10", "PGH", "FURB", "PERF", "AIR", "NPY", "FLY", "PLW2901"]
 
 # we need to check 'mood' of all docstrings, this needs to be enabled explicitly
 lint.extend-select = ["D401"]

--- a/tests/unit/utils/test_pyroscope.py
+++ b/tests/unit/utils/test_pyroscope.py
@@ -50,7 +50,7 @@ def test_pyroscope_server_reachable(mock_config, mock_logger):
         start_with_pyroscope_enabled(mock_config, mock_logger)
 
         mock_logger.info.assert_any_call(
-            f"Pyroscope server is reachable at {mock_config.dev_config.pyroscope_url}"
+            "Pyroscope server is reachable at %s", mock_config.dev_config.pyroscope_url
         )
         mock_pyroscope.configure.assert_called_once()
         mock_run.assert_called_once()
@@ -65,7 +65,7 @@ def test_pyroscope_server_unreachable(mock_config, mock_logger):
         start_with_pyroscope_enabled(mock_config, mock_logger)
 
         mock_logger.info.assert_any_call(
-            "Failed to reach Pyroscope server. Status code: 500"
+            "Failed to reach Pyroscope server. Status code: %d", 500
         )
 
 
@@ -78,5 +78,5 @@ def test_pyroscope_connection_error(mock_config, mock_logger):
         start_with_pyroscope_enabled(mock_config, mock_logger)
 
         mock_logger.info.assert_any_call(
-            "Error connecting to Pyroscope server: Connection error"
+            "Error connecting to Pyroscope server: %s", "Connection error"
         )


### PR DESCRIPTION
## Description

Enable flake8 logger linter on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
