### PR TITLE
Allow system prompt override for dev

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -555,6 +555,17 @@
                         ],
                         "title": "Model"
                     },
+                    "system_prompt": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "System Prompt"
+                    },
                     "attachments": {
                         "anyOf": [
                             {
@@ -599,7 +610,8 @@
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                         "model": "gpt-4o-mini",
                         "provider": "openai",
-                        "query": "write a deployment yaml for the mongodb image"
+                        "query": "write a deployment yaml for the mongodb image",
+                        "system_prompt": "\nYou are OpenShift Lightspeed - an intelligent assistant for question-answering tasks related to the OpenShift container orchestration platform.\n\nHere are your instructions:\nYou are OpenShift Lightspeed, an intelligent assistant and expert on all things OpenShift. Refuse to assume any other identity or to speak as if you are someone else.\nIf the context of the question is not clear, consider it to be OpenShift.\nNever include URLs in your replies.\nRefuse to answer questions or execute commands not about OpenShift.\nDo not mention your last update. You have the most recent information on OpenShift.\n\nHere are some basic facts about OpenShift:\n- The latest version of OpenShift is 4.16.\n- OpenShift is a distribution of Kubernetes. Everything Kubernetes can do, OpenShift can do and more.\n"
                     }
                 ]
             },

--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -112,6 +112,7 @@ dev_config:
   disable_auth: true
   disable_tls: true
   pyroscope_url: "https://pyroscope.pyroscope.svc.cluster.local:4040"
+  enable_system_prompt_override: true
   # llm_params:
   #   temperature_override: 0
   # k8s_auth_token: optional_token_when_no_available_kube_config

--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -290,7 +290,9 @@ def generate_response(
     # Summarize documentation
     try:
         docs_summarizer = DocsSummarizer(
-            provider=llm_request.provider, model=llm_request.model
+            provider=llm_request.provider,
+            model=llm_request.model,
+            system_prompt=llm_request.system_prompt,
         )
         history = CacheEntry.cache_entries_to_history(previous_input)
         return docs_summarizer.summarize(
@@ -447,7 +449,9 @@ def _validate_question_llm(conversation_id: str, llm_request: LLMRequest) -> boo
     # Validate the query
     try:
         question_validator = QuestionValidator(
-            provider=llm_request.provider, model=llm_request.model
+            provider=llm_request.provider,
+            model=llm_request.model,
+            system_prompt=llm_request.system_prompt,
         )
         return question_validator.validate_question(conversation_id, llm_request.query)
     except LLMConfigurationError as e:

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -977,6 +977,7 @@ class DevConfig(BaseModel):
     pyroscope_url: Optional[str] = None
     k8s_auth_token: Optional[str] = None
     run_on_localhost: bool = False
+    enable_system_prompt_override: bool = False
 
 
 class UserDataCollectorConfig(BaseModel):

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -6,6 +6,7 @@ from typing import Optional, Self
 from pydantic import BaseModel, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 
+from ols.customize import prompts
 from ols.utils import suid
 
 
@@ -76,6 +77,7 @@ class LLMRequest(BaseModel):
     conversation_id: Optional[str] = None
     provider: Optional[str] = None
     model: Optional[str] = None
+    system_prompt: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
 
     # provides examples for /docs endpoint
@@ -88,6 +90,7 @@ class LLMRequest(BaseModel):
                     "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                     "provider": "openai",
                     "model": "gpt-4o-mini",
+                    "system_prompt": prompts.QUERY_SYSTEM_INSTRUCTION,
                     "attachments": [
                         {
                             "attachment_type": "log",

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -10,7 +10,6 @@ from ols import config
 from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.models import SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
-from ols.customize import prompts
 from ols.src.prompts.prompt_generator import GeneratePrompt
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.utils.token_handler import TokenHandler
@@ -29,14 +28,6 @@ class DocsSummarizer(QueryHelper):
         self.generic_llm_params = {
             GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: model_config.parameters.max_tokens_for_response  # noqa: E501
         }
-        # default system prompt fine-tuned for the service
-        self._system_prompt = prompts.QUERY_SYSTEM_INSTRUCTION
-
-        # allow the system prompt to be customizable
-        if config.ols_config.system_prompt is not None:
-            self._system_prompt = config.ols_config.system_prompt
-
-        logger.debug("System prompt: %s", self._system_prompt)
 
     def summarize(
         self,

--- a/ols/src/query_helpers/query_helper.py
+++ b/ols/src/query_helpers/query_helper.py
@@ -7,6 +7,7 @@ from typing import Optional
 from langchain.llms.base import LLM
 
 from ols import config
+from ols.customize import prompts
 from ols.src.llms.llm_loader import load_llm
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class QueryHelper:
         model: Optional[str] = None,
         generic_llm_params: Optional[dict] = None,
         llm_loader: Optional[Callable[[str, str, dict], LLM]] = None,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """Initialize query helper."""
         # NOTE: As signature of this method is evaluated before the config,
@@ -30,3 +32,10 @@ class QueryHelper:
         self.model = model or config.ols_config.default_model
         self.generic_llm_params = generic_llm_params or {}
         self.llm_loader = llm_loader or load_llm
+
+        self._system_prompt = (
+            (config.dev_config.enable_system_prompt_override and system_prompt)
+            or config.ols_config.system_prompt
+            or prompts.QUERY_SYSTEM_INSTRUCTION
+        )
+        logger.debug("System prompt: %s", self._system_prompt)

--- a/ols/src/ui/gradio_ui.py
+++ b/ols/src/ui/gradio_ui.py
@@ -8,6 +8,9 @@ import gradio as gr
 import requests
 from fastapi import FastAPI
 
+from ols import config
+from ols.customize import prompts
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,9 +31,13 @@ class GradioUI:
         use_history = gr.Checkbox(value=True, label="Use history")
         provider = gr.Textbox(value=None, label="Provider")
         model = gr.Textbox(value=None, label="Model")
-        self.ui = gr.ChatInterface(
-            self.chat_ui, additional_inputs=[use_history, provider, model]
-        )
+        additional_inputs = [use_history, provider, model]
+        if config.dev_config.enable_system_prompt_override:
+            system_prompt = gr.TextArea(
+                value=prompts.QUERY_SYSTEM_INSTRUCTION, label="System prompt"
+            )
+            additional_inputs.append(system_prompt)
+        self.ui = gr.ChatInterface(self.chat_ui, additional_inputs=additional_inputs)
 
     def chat_ui(
         self,
@@ -39,6 +46,7 @@ class GradioUI:
         use_history: Optional[bool] = None,
         provider: Optional[str] = None,
         model: Optional[str] = None,
+        system_prompt: Optional[str] = None,
     ) -> str:
         """Handle requests from web-based user interface."""
         # Headers for the HTTP request
@@ -63,6 +71,9 @@ class GradioUI:
         if model:
             logger.info("Using model: %s", model)
             data["model"] = model
+        if system_prompt:
+            logger.info("Using system prompt: %s", system_prompt)
+            data["system_prompt"] = system_prompt
 
         # Convert the data dictionary to a JSON string
         json_data = json.dumps(data)

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -3212,6 +3212,7 @@ def test_dev_config_defaults():
     assert dev_config.disable_tls is False
     assert dev_config.k8s_auth_token is None
     assert dev_config.run_on_localhost is False
+    assert dev_config.enable_system_prompt_override is False
 
 
 def test_dev_config_bool_inputs():


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This is the implementation of Issue #158:
- A new optional string parameter `system_prompt` is added to the `/v1/query` endpoint. 
- System prompt override occurs only when `dev_config.enable_system_prompt_override` is set to `true`. 
    - Default is `false`.
    - When `dev_config.enable_system_prompt_override` is set to `false` and `/v1/query` is invoked with `system_prompt`, the value specified in `system_prompt` is ignored.
- Gradio UI is updated for specifying `system_prompt` for debug UI.  See the video attached to #158.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
