### PR TITLE
Allow reranking nodes retrieved from vector DB

### DIFF
--- a/ols/customize/__init__.py
+++ b/ols/customize/__init__.py
@@ -6,3 +6,4 @@ import os
 project = os.getenv("PROJECT", "ols")
 prompts = importlib.import_module(f"ols.customize.{project}.prompts")
 keywords = importlib.import_module(f"ols.customize.{project}.keywords")
+reranker = importlib.import_module(f"ols.customize.{project}.reranker")

--- a/ols/customize/ols/reranker.py
+++ b/ols/customize/ols/reranker.py
@@ -1,0 +1,14 @@
+"""Reranker for post-processing the Vector DB search results."""
+
+import logging
+
+from llama_index.core.schema import NodeWithScore
+
+logger = logging.getLogger(__name__)
+
+
+def rerank(retrieved_nodes: list[NodeWithScore]) -> list[NodeWithScore]:
+    """Rerank Vector DB search results."""
+    message = f"reranker.rerank() is called with {len(retrieved_nodes)} result(s)."
+    logger.debug(message)
+    return retrieved_nodes

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -10,7 +10,6 @@ from ols import config
 from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.models import SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
-from ols.customize import prompts
 from ols.customize.ols.reranker import rerank
 from ols.src.prompts.prompt_generator import GeneratePrompt
 from ols.src.query_helpers.query_helper import QueryHelper

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -10,6 +10,8 @@ from ols import config
 from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.models import SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
+from ols.customize import prompts
+from ols.customize.ols.reranker import rerank
 from ols.src.prompts.prompt_generator import GeneratePrompt
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.utils.token_handler import TokenHandler
@@ -80,8 +82,10 @@ class DocsSummarizer(QueryHelper):
 
         if vector_index is not None:
             retriever = vector_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
+            retrieved_nodes = retriever.retrieve(query)
+            retrieved_nodes = rerank(retrieved_nodes)
             rag_chunks, available_tokens = token_handler.truncate_rag_context(
-                retriever.retrieve(query), self.model, available_tokens
+                retrieved_nodes, self.model, available_tokens
             )
         else:
             logger.warning("Proceeding without RAG content. Check start up messages.")


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

We (Ansible Lightspeed Chatbot) are adding supplemental documents that will include what are not explicitly found in the product documentation. When those documents appear in DB search results, we want place them at higher ranks over other documents. For that purpose, we would like to allow reranking of Vector DB search results before truncating them within the token limit.  

The "reranker" is defined in the "custom" directory so that each product can define its own reranker.  The efault implementation does nothing and returns the given search results as they are.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
