### PR TITLE
Get rid of global variables in integration tests

### DIFF
--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -10,8 +10,6 @@ from fastapi.testclient import TestClient
 from ols import config
 from ols.constants import CONFIGURATION_FILE_NAME_ENV_VARIABLE
 
-client: TestClient
-
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
@@ -24,18 +22,17 @@ client: TestClient
 )
 def _setup():
     """Setups the test client."""
-    global client
     config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app  # pylint: disable=C0415
 
-    client = TestClient(app)
+    pytest.client = TestClient(app)
 
 
 def test_liveness():
     """Test handler for /liveness REST API endpoint."""
-    response = client.get("/liveness")
+    response = pytest.client.get("/liveness")
     assert response.status_code == requests.codes.ok
     assert response.json() == {"alive": True}
 
@@ -47,7 +44,7 @@ def test_readiness():
         patch("ols.app.endpoints.health.llm_is_ready", return_value=True),
         patch("ols.app.endpoints.health.index_is_ready", return_value=False),
     ):
-        response = client.get("/readiness")
+        response = pytest.client.get("/readiness")
         assert response.status_code == requests.codes.service_unavailable
         assert response.json() == {
             "detail": {
@@ -61,7 +58,7 @@ def test_readiness():
         patch("ols.app.endpoints.health.llm_is_ready", return_value=False),
         patch("ols.app.endpoints.health.index_is_ready", return_value=True),
     ):
-        response = client.get("/readiness")
+        response = pytest.client.get("/readiness")
         assert response.status_code == requests.codes.service_unavailable
         assert response.json() == {
             "detail": {"response": "Service is not ready", "cause": "LLM is not ready"}
@@ -72,6 +69,6 @@ def test_readiness():
         patch("ols.app.endpoints.health.llm_is_ready", return_value=True),
         patch("ols.app.endpoints.health.index_is_ready", return_value=True),
     ):
-        response = client.get("/readiness")
+        response = pytest.client.get("/readiness")
         assert response.status_code == requests.codes.ok
         assert response.json() == {"ready": True, "reason": "service is ready"}

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -11,8 +11,6 @@ from fastapi.testclient import TestClient
 from ols import config
 from ols.constants import CONFIGURATION_FILE_NAME_ENV_VARIABLE
 
-client: TestClient
-
 
 # we need to patch the config file path to point to the test
 # config file before we import anything from main.py
@@ -25,18 +23,17 @@ client: TestClient
 )
 def _setup():
     """Setups the test client."""
-    global client
     config.reload_from_yaml_file("tests/config/config_for_integration_tests.yaml")
 
     # app.main need to be imported after the configuration is read
     from ols.app.main import app  # pylint: disable=C0415
 
-    client = TestClient(app)
+    pytest.client = TestClient(app)
 
 
 def test_openapi_endpoint():
     """Check if REST API provides endpoint with OpenAPI specification."""
-    response = client.get("/openapi.json")
+    response = pytest.client.get("/openapi.json")
     assert response.status_code == requests.codes.ok
 
     # this line ensures that response payload contains proper JSON
@@ -67,7 +64,7 @@ def test_openapi_content():
         pre_generated_schema = json.load(fin)
 
     # retrieve current OpenAPI schema
-    response = client.get("/openapi.json")
+    response = pytest.client.get("/openapi.json")
     assert response.status_code == requests.codes.ok
     current_schema = response.json()
 

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -9,14 +9,10 @@ from ols.src.cache.redis_cache import RedisCache
 USER_ID = "00000000-0000-0000-0000-000000000001"
 CONVERSATION_ID = "00000000-0000-0000-0000-000000000002"
 
-redis_cache: RedisCache
-
 
 @pytest.mark.redis
 def setup():
     """Setups the Redis client."""
-    global redis_cache
-
     # please note that the setup expect Redis running locally on default port
     redis_config = RedisConfig(
         {
@@ -29,25 +25,25 @@ def setup():
         }
     )
 
-    redis_cache = RedisCache(redis_config)
+    pytest.redis_cache = RedisCache(redis_config)
 
 
 @pytest.mark.redis
 def test_conversation_in_redis():
     """Check the elementary GET operation and insert_or_append operation."""
     # make sure the cache is empty
-    redis_cache.redis_client.delete(USER_ID + ":" + CONVERSATION_ID)
+    pytest.redis_cache.redis_client.delete(USER_ID + ":" + CONVERSATION_ID)
 
     # the initial value should be empty
-    retrieved = redis_cache.get(USER_ID, CONVERSATION_ID)
+    retrieved = pytest.redis_cache.get(USER_ID, CONVERSATION_ID)
     assert retrieved is None
 
     # insert some conversation
     cache_entry = CacheEntry(query="First human message", response="First AI response")
-    redis_cache.insert_or_append(USER_ID, CONVERSATION_ID, cache_entry)
+    pytest.redis_cache.insert_or_append(USER_ID, CONVERSATION_ID, cache_entry)
 
     # check what is stored in conversation cache
-    retrieved = redis_cache.get(USER_ID, CONVERSATION_ID)
+    retrieved = pytest.redis_cache.get(USER_ID, CONVERSATION_ID)
     assert retrieved is not None
 
     # just the initial cache_entry should be stored
@@ -58,10 +54,10 @@ def test_conversation_in_redis():
         query="Second human message", response="Second AI response"
     )
 
-    redis_cache.insert_or_append(USER_ID, CONVERSATION_ID, cache_entry_2)
+    pytest.redis_cache.insert_or_append(USER_ID, CONVERSATION_ID, cache_entry_2)
 
     # check what is stored in conversation cache
-    retrieved = redis_cache.get(USER_ID, CONVERSATION_ID)
+    retrieved = pytest.redis_cache.get(USER_ID, CONVERSATION_ID)
     assert retrieved is not None
 
     # now both conversations should be stored


### PR DESCRIPTION
## Description

Get rid of global variables in integration tests

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Integration tests
