### PR TITLE
Support non-default uvicorn port number for dev

### DIFF
--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -113,6 +113,7 @@ dev_config:
   disable_tls: true
   pyroscope_url: "https://pyroscope.pyroscope.svc.cluster.local:4040"
   enable_system_prompt_override: true
+  # uvicorn_port_number: 8081
   # llm_params:
   #   temperature_override: 0
   # k8s_auth_token: optional_token_when_no_available_kube_config

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -978,6 +978,7 @@ class DevConfig(BaseModel):
     k8s_auth_token: Optional[str] = None
     run_on_localhost: bool = False
     enable_system_prompt_override: bool = False
+    uvicorn_port_number: Optional[int] = None
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""

--- a/ols/runners/uvicorn.py
+++ b/ols/runners/uvicorn.py
@@ -16,7 +16,11 @@ def start_uvicorn(config: config_model.Config) -> None:
         if config.dev_config.run_on_localhost
         else "0.0.0.0"  # noqa: S104 # nosec: B104
     )
-    port = 8080 if config.dev_config.disable_tls else 8443
+    port = (
+        config.dev_config.uvicorn_port_number
+        if config.dev_config.uvicorn_port_number
+        else 8080 if config.dev_config.disable_tls else 8443
+    )
     log_level = config.ols_config.logging_config.uvicorn_log_level
 
     # The tls fields can be None, which means we will pass those values as None to uvicorn.run

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -3228,6 +3228,7 @@ def test_dev_config_defaults():
     assert dev_config.k8s_auth_token is None
     assert dev_config.run_on_localhost is False
     assert dev_config.enable_system_prompt_override is False
+    assert dev_config.uvicorn_port_number is None
 
 
 def get_dev_configs():

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -92,3 +92,23 @@ def test_start_uvicorn_on_localhost(mocked_run, default_config):
         ssl_ciphers="TLSv1",
         access_log=False,
     )
+
+
+@patch("uvicorn.run")
+def test_start_uvicorn_on_non_default_port(mocked_run, default_config):
+    """Test the function to start Uvicorn server on a non-default port."""
+    default_config.dev_config.uvicorn_port_number = 8081
+    start_uvicorn(default_config)
+    mocked_run.assert_called_once_with(
+        "ols.app.main:app",
+        host="0.0.0.0",  # noqa: S104
+        port=8081,
+        workers=1,
+        log_level=30,
+        ssl_keyfile=None,
+        ssl_certfile=None,
+        ssl_keyfile_password=None,
+        ssl_version=17,
+        ssl_ciphers="TLSv1",
+        access_log=False,
+    )


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In a development environment, we want to change the port number of the service, which is hard-coded to `8080` with non-secure connection. This PR will add a new configurable option `uvicorn_port_number` to `dev_config` so that developers can modify the service port number without editing a source code. When `uvicorn_port_number` is not specified, the code will work as it does today.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Unit test cases are provided with the PR.
