### PR TITLE
Reranker should be unique per project

### DIFF
--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -10,7 +10,7 @@ from ols import config
 from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.models import SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
-from ols.customize.ols.reranker import rerank
+from ols.customize import reranker
 from ols.src.prompts.prompt_generator import GeneratePrompt
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.utils.token_handler import TokenHandler
@@ -82,7 +82,7 @@ class DocsSummarizer(QueryHelper):
         if vector_index is not None:
             retriever = vector_index.as_retriever(similarity_top_k=RAG_CONTENT_LIMIT)
             retrieved_nodes = retriever.retrieve(query)
-            retrieved_nodes = rerank(retrieved_nodes)
+            retrieved_nodes = reranker.rerank(retrieved_nodes)
             rag_chunks, available_tokens = token_handler.truncate_rag_context(
                 retrieved_nodes, self.model, available_tokens
             )


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
#228 had a bug. It introduced "Reranker", which was suppsed to be provided per project, but in `docs_summarizer.py`, the OLS-version of reranker was statically linked to the code.  This PR is for fixing that issue.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Issue a regular `/query` call to make sure that it is processed correctly.
