### PR TITLE
Separate RAG content and embeddings images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,11 @@
 # vim: set filetype=dockerfile
 ARG LIGHTSPEED_RAG_CONTENT_IMAGE=quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:3e96332648a6f8ff1879c7ae11c818ea7f1c8d5b8a99c4bff406c98c8a7d4541
+ARG LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/openshift-lightspeed/lightspeed-rag-content@sha256:3e96332648a6f8ff1879c7ae11c818ea7f1c8d5b8a99c4bff406c98c8a7d4541
 ARG RAG_CONTENTS_SUB_FOLDER=vector_db/ocp_product_docs
 
 FROM ${LIGHTSPEED_RAG_CONTENT_IMAGE} as lightspeed-rag-content
+
+FROM ${LIGHTSPEED_RAG_EMBEDDINGS_IMAGE} as lightspeed-rag-embeddings
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
@@ -25,7 +28,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app-root
 
 COPY --from=lightspeed-rag-content /rag/${RAG_CONTENTS_SUB_FOLDER} ${APP_ROOT}/${RAG_CONTENTS_SUB_FOLDER}
-COPY --from=lightspeed-rag-content /rag/embeddings_model ./embeddings_model
+COPY --from=lightspeed-rag-embeddings /rag/embeddings_model ./embeddings_model
 
 # Add explicit files and directories
 # (avoid accidental inclusion of local directories or env files or credentials)

--- a/ols/utils/ssl.py
+++ b/ols/utils/ssl.py
@@ -1,5 +1,7 @@
 """Utility function for retrieving SSL version and list of ciphers for TLS secutiry profile."""
 
+# ruff: noqa:A005
+
 import logging
 from typing import Optional
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We (Ansible Lightspeed) want to separate RAG content and embeddings images for building the service image.  Currently our RAG content image is about 3.1 GB, but the RAG content is only about 30 MB. 99% of the image was used for storing embeddings downloaded from HuggingFace. Since the embeddings used for chatbot are not updated frequently, including embeddings in the RAG content image is not efficient.

Note that both RAG content and embedding images point to the same image in this PR so that OLS build won't break, but it is possible to separate images by giving arguments in our downstream repo (ansible-chatbot-service).

## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Run Konflux builds to verify builds won't break.
