### PR TITLE
AAP-38368: Fixing sample prompt tokens calculations, which may cause further available token calculation issues

### DIFF
--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -13,6 +13,11 @@ from ols.constants import ModelFamily
 from ols.customize import prompts
 
 
+def restructure_rag_context(text: str, model: str) -> str:
+    """Restructure rag text by appending special characters.."""
+    return restructure_rag_context_post(restructure_rag_context_pre(text, model), model)
+
+
 def restructure_rag_context_pre(text: str, model: str) -> str:
     """Restructure rag text - pre truncation."""
     if ModelFamily.GRANITE in model:

--- a/ols/src/query_helpers/docs_summarizer.py
+++ b/ols/src/query_helpers/docs_summarizer.py
@@ -12,7 +12,11 @@ from ols.app.metrics import TokenMetricUpdater
 from ols.app.models.models import RagChunk, SummarizerResponse
 from ols.constants import RAG_CONTENT_LIMIT, GenericLLMParameters
 from ols.customize import prompts, reranker
-from ols.src.prompts.prompt_generator import GeneratePrompt
+from ols.src.prompts.prompt_generator import (
+    GeneratePrompt,
+    restructure_history,
+    restructure_rag_context,
+)
 from ols.src.query_helpers.query_helper import QueryHelper
 from ols.utils.token_handler import TokenHandler
 
@@ -80,7 +84,12 @@ class DocsSummarizer(QueryHelper):
         # Use sample text for context/history to get complete prompt
         # instruction. This is used to calculate available tokens.
         temp_prompt, temp_prompt_input = GeneratePrompt(
-            query, ["sample"], ["ai: sample"], self.system_prompt
+            # Sample prompt's context/history must be re-structured for the given model,
+            # to ensure the further right available token calculation.
+            query,
+            [restructure_rag_context("sample", self.model)],
+            [restructure_history("ai: sample", self.model)],
+            self._system_prompt,
         ).generate_prompt(self.model)
 
         available_tokens = token_handler.calculate_and_check_available_tokens(

--- a/ols/utils/token_handler.py
+++ b/ols/utils/token_handler.py
@@ -103,7 +103,7 @@ class TokenHandler:
             context_window_size - max_tokens_for_response - prompt_token_count
         )
 
-        if available_tokens <= 0:
+        if available_tokens < 0:
             limit = context_window_size - max_tokens_for_response
             raise PromptTooLongError(
                 f"Prompt length {prompt_token_count} exceeds LLM "

--- a/tests/unit/prompts/test_prompt_generator.py
+++ b/tests/unit/prompts/test_prompt_generator.py
@@ -17,8 +17,7 @@ from ols.constants import (
 from ols.src.prompts.prompt_generator import (
     GeneratePrompt,
     restructure_history,
-    restructure_rag_context_post,
-    restructure_rag_context_pre,
+    restructure_rag_context,
 )
 
 model = [GRANITE_13B_CHAT_V2, GPT35_TURBO]
@@ -33,10 +32,7 @@ conversation_history = ["human: First human message", "ai: First AI message"]
 
 def _restructure_prompt_input(rag_context, conversation_history, model):
     """Restructure prompt input."""
-    rag_formatted = [
-        restructure_rag_context_post(restructure_rag_context_pre(text, model), model)
-        for text in rag_context
-    ]
+    rag_formatted = [restructure_rag_context(text, model) for text in rag_context]
     history_formatted = [
         restructure_history(history, model) for history in conversation_history
     ]


### PR DESCRIPTION
## Description

In some situations, the OLS itself fails with an error of token limit exceeded (without even flowing to the LLM):
```
OLS controlled 413 http error: Prompt is too long
```

Although considering OLS token calculation may differ at some point from the LLM, this situation means some actual token calculations in the OLS code-base are prune to error.

So this is a fix for the OLS token calculation for available context (documents/history) length. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- https://issues.redhat.com/browse/AAP-38368

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
In order to test it locally, I did:

1.- Set a small `context_window_size`, in order to quickly reproduce max_length issues, for example `2048`, and target `Granite 3.0` model provider

2.- Then just use an example prompt which causes relevant documents to exceed the available tokens, given expected response tokens of `1024`), as example use this user query: `explain ansible lightspeed features`

3.- Then the OLS service itself returns an error like: `OLS controlled 413 http error: Prompt is too long`

4.- After applying this PR's changes, it works

5.- Same happens with context's history (as for RAG in point 2), just reduce the `context_window_size` and use several history items to reproduce.
