### PR TITLE
Re-enable system prompt override

### DIFF
--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -58,7 +58,7 @@ def test_if_system_prompt_was_updated():
     summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
     # expected prompt was loaded during configuration phase
     expected_prompt = config.ols_config.system_prompt
-    assert summarizer.system_prompt == expected_prompt
+    assert summarizer._system_prompt == expected_prompt
 
 
 def test_docs_summarizer_streaming_parameter():


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
System Prompt Override added with #227 is no longer working.  System prompt was set using the
`_system_prompt` attribute of  `QueryHelper` class. However, the `DocsSummarizer` class, which extends
`QueryHelper`, now has `system_prompt` attribute, which does not contain the logic required for
System Prompt Override. We can simply use the `_system_prompt` attribute as it is set in the constructor
of `QueryHelper`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
  Ansible Lightspeed chatbot has the UI to override system prompt and it can be used for verification.
