### PR TITLE
Add Additional Config File Loading

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -18,6 +18,7 @@ from pydantic import (
 from ols import constants
 from ols.utils import checks, tls
 
+
 class ModelParameters(BaseModel):
     """Model parameters."""
 
@@ -502,20 +503,22 @@ class LLMProviders(BaseModel):
         all_servers = lightspeed.get("servers")
         if all_servers is None:
             raise KeyError("No lightspeed servers defined.")
-        checks.expand_lightspeed_environment_variables(all_servers)
+        checks.expands_lightspeed_environment_variables(all_servers)
         new_providers = self._parse_rhdh_lightspeed_config(all_servers)
         for provider in new_providers:
             if provider.name not in self.providers:
                 self.providers[provider.name] = provider
 
     def _parse_rhdh_lightspeed_config(self, data: list[dict]) -> list[ProviderConfig]:
-        """Private helper for converting Red Hat Developer Hub configuration file declared model data to Road-Core Service readable data."""
+        """Private helper for converting RHDH config file model data to RCS readable data."""
         all_converted_providers = []
         for server in data:
             formatted_data = {}
             name = server.get("id")
             url = server.get("url")
-            models = server.get("models")  # Current lightspeed docs don't require model_name but is a requirement of road-core config.
+            models = server.get(
+                "models"
+            )  # OLS doesn't require model_name but is a requirement of road-core config.
             model_type = server.get("type")
             token = server.get("token")
             if name is None:

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -506,7 +506,7 @@ class LLMProviders(BaseModel):
         checks.expands_lightspeed_environment_variables(all_servers)
         new_providers = self._parse_rhdh_lightspeed_config(all_servers)
         for provider in new_providers:
-            if provider.name not in self.providers:
+            if provider.name not in self.providers and provider.name is not None:
                 self.providers[provider.name] = provider
 
     def _parse_rhdh_lightspeed_config(self, data: list[dict]) -> list[ProviderConfig]:

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -204,12 +204,15 @@ DEFAULT_AUTHENTICATION_MODULE = "k8s"
 # All supported authentication modules
 SUPPORTED_AUTHENTICATION_MODULES = {"k8s", "noop"}
 
-# Default configuration file name
+# Default configuration file name for RCS
 DEFAULT_CONFIGURATION_FILE = "rcsconfig.yaml"
 
 # Environment variable containing configuration file name to override default
 # configuration file
 CONFIGURATION_FILE_NAME_ENV_VARIABLE = "RCS_CONFIG_FILE"
+
+# Optional environment variable containing RHDH app config file
+RHDH_CONFIGURATION_FILE_NAME_ENV_VARIABLE = "RHDH_CONFIG_FILE"
 
 # Response streaming media types
 MEDIA_TYPE_TEXT = "text/plain"

--- a/ols/utils/checks.py
+++ b/ols/utils/checks.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -97,3 +98,19 @@ def get_log_level(value: str) -> int:
             f"{[k.lower() for k in logging.getLevelNamesMapping()]}"
         )
     return log_level
+
+def expand_lightspeed_environment_variables(data: list[dict]) -> None:
+    """Expands environment variables declared in RHDH config files for lightspeed."""
+    env_var_pattern = r"\$\{([\w]+)\}"
+    for server in data:
+        for k, v in server.items():
+            if k == "models": # skip over looking through the model names list
+                continue
+            matched_value = re.match(env_var_pattern, v)
+            if matched_value is None:
+                continue
+            expanded = os.getenv(matched_value.group(1))
+            if expanded is None:
+                raise Exception(f"Environment variable referenced but not set. {matched_value.group()}")
+            clean_expanded = expanded.strip()
+            server[k] = clean_expanded

--- a/ols/utils/checks.py
+++ b/ols/utils/checks.py
@@ -99,18 +99,21 @@ def get_log_level(value: str) -> int:
         )
     return log_level
 
-def expand_lightspeed_environment_variables(data: list[dict]) -> None:
-    """Expands environment variables declared in RHDH config files for lightspeed."""
+
+def expands_lightspeed_environment_variables(data: list[dict]) -> None:
+    """Expand environment variables declared in RHDH config files for lightspeed."""
     env_var_pattern = r"\$\{([\w]+)\}"
     for server in data:
         for k, v in server.items():
-            if k == "models": # skip over looking through the model names list
+            if k == "models":  # skip over looking through the model names list
                 continue
             matched_value = re.match(env_var_pattern, v)
             if matched_value is None:
                 continue
             expanded = os.getenv(matched_value.group(1))
             if expanded is None:
-                raise Exception(f"Environment variable referenced but not set. {matched_value.group()}")
+                raise Exception(
+                    f"Environment variable referenced but not set. {matched_value.group()}"
+                )
             clean_expanded = expanded.strip()
             server[k] = clean_expanded

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -123,6 +123,25 @@ class AppConfig:
             print(f"Failed to load config file {config_file}: {e!s}")
             print(traceback.format_exc())
             raise
+    
+    def reload_additional_config_file(
+            self,
+            file_path: str,
+            type: str
+    ) -> None:
+        """Reload an additional configuration file that is separate from the standard RCS config."""
+        try:
+            with open(file_path, encoding="utf-8") as opened_file:
+                data = yaml.safe_load(opened_file)
+                match type:
+                    case "rhdh":
+                        pass
+                    case _:
+                        raise ValueError(f"Configuration file type '{type}' not recognized.")
+        except Exception as e:
+            print(f"Failed to load an additional configuration file {file_path}: {e!s}")
+            print(traceback.format_exc())
+            raise
 
 
 config: AppConfig = AppConfig()

--- a/ols/utils/config.py
+++ b/ols/utils/config.py
@@ -123,21 +123,19 @@ class AppConfig:
             print(f"Failed to load config file {config_file}: {e!s}")
             print(traceback.format_exc())
             raise
-    
-    def reload_additional_config_file(
-            self,
-            file_path: str,
-            type: str
-    ) -> None:
+
+    def reload_additional_config_file(self, file_path: str, file_type: str) -> None:
         """Reload an additional configuration file that is separate from the standard RCS config."""
         try:
             with open(file_path, encoding="utf-8") as opened_file:
                 data = yaml.safe_load(opened_file)
-                match type:
+                match file_type:
                     case "rhdh":
-                        pass
+                        self.config.llm_providers.add_lightspeed_providers(data)
                     case _:
-                        raise ValueError(f"Configuration file type '{type}' not recognized.")
+                        raise ValueError(
+                            f"Configuration file type '{file_type}' not recognized."
+                        )
         except Exception as e:
             print(f"Failed to load an additional configuration file {file_path}: {e!s}")
             print(traceback.format_exc())

--- a/runner.py
+++ b/runner.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         CONFIGURATION_FILE_NAME_ENV_VARIABLE, DEFAULT_CONFIGURATION_FILE
     )
     config.reload_from_yaml_file(cfg_file)
-
+    
     # Optional environment variable representing RHDH app config file.
     rhdh_cfg_file = os.environ.get(RHDH_CONFIGURATION_FILE_NAME_ENV_VARIABLE)
     if rhdh_cfg_file is not None:
@@ -58,7 +58,8 @@ if __name__ == "__main__":
     logger = logging.getLogger("ols")
     configure_logging(config.ols_config.logging_config)
     logger.info("Config loaded from %s", Path(cfg_file).resolve())
-    logger.info("Extra configuration loaded from %s", Path(rhdh_cfg_file).resolve())
+    if rhdh_cfg_file is not None:
+        logger.info("Extra configuration loaded from %s", Path(rhdh_cfg_file).resolve())
     logger.info("Running on Python version %s", sys.version)
     configure_hugging_face_envs(config.ols_config)
 

--- a/runner.py
+++ b/runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ols.constants import (
     CONFIGURATION_FILE_NAME_ENV_VARIABLE,
     DEFAULT_CONFIGURATION_FILE,
+    RHDH_CONFIGURATION_FILE_NAME_ENV_VARIABLE,
 )
 from ols.runners.uvicorn import start_uvicorn
 from ols.src.auth.auth import use_k8s_auth
@@ -44,6 +45,11 @@ if __name__ == "__main__":
     )
     config.reload_from_yaml_file(cfg_file)
 
+    # Optional environment variable representing RHDH app config file.
+    rhdh_cfg_file = os.environ.get(RHDH_CONFIGURATION_FILE_NAME_ENV_VARIABLE)
+    if rhdh_cfg_file is not None:
+        config.reload_additional_config_file(rhdh_cfg_file, "rhdh")
+    
     if "--dump-config" in sys.argv:
         with open("olsconfig.json", "w", encoding="utf-8") as fout:
             fout.write(config.config.json())
@@ -52,6 +58,7 @@ if __name__ == "__main__":
     logger = logging.getLogger("ols")
     configure_logging(config.ols_config.logging_config)
     logger.info("Config loaded from %s", Path(cfg_file).resolve())
+    logger.info("Extra configuration loaded from %s", Path(rhdh_cfg_file).resolve())
     logger.info("Running on Python version %s", sys.version)
     configure_hugging_face_envs(config.ols_config)
 

--- a/runner.py
+++ b/runner.py
@@ -44,12 +44,12 @@ if __name__ == "__main__":
         CONFIGURATION_FILE_NAME_ENV_VARIABLE, DEFAULT_CONFIGURATION_FILE
     )
     config.reload_from_yaml_file(cfg_file)
-    
+
     # Optional environment variable representing RHDH app config file.
     rhdh_cfg_file = os.environ.get(RHDH_CONFIGURATION_FILE_NAME_ENV_VARIABLE)
     if rhdh_cfg_file is not None:
         config.reload_additional_config_file(rhdh_cfg_file, "rhdh")
-    
+
     if "--dump-config" in sys.argv:
         with open("olsconfig.json", "w", encoding="utf-8") as fout:
             fout.write(config.config.json())

--- a/tests/config/invalid_rhdh_config.yaml
+++ b/tests/config/invalid_rhdh_config.yaml
@@ -1,0 +1,79 @@
+app:
+  title: RHDH Lightspeed
+  baseUrl: http://localhost:3000
+
+organization:
+  name: Red Hat
+
+backend:
+  # Used for enabling authentication, secret is shared by all backend plugins
+  # See https://backstage.io/docs/auth/service-to-service-auth for
+  # information on the format
+  # auth:
+  #   keys:
+  #     - secret: ${BACKEND_SECRET}
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+    # Uncomment the following host directive to bind to specific interfaces
+    # host: 127.0.0.1
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+  cors:
+    origin: http://localhost:3000
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  # This is for local development only, it is not recommended to use this in production
+  # The production database configuration is stored in app-config.production.yaml
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
+
+integrations:
+  github:
+    - host: github.com
+      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
+      # about setting up the GitHub integration here: https://backstage.io/docs/integrations/github/locations#configuration
+      token: ${GITHUB_TOKEN}
+    ### Example for how to add your GitHub Enterprise instance using the API:
+    # - host: ghe.example.net
+    #   apiBaseUrl: https://ghe.example.net/api/v3
+    #   token: ${GHE_TOKEN}
+
+  ### Example for how to add a proxy endpoint for the frontend.
+  ### A typical reason to do this is to handle HTTPS and CORS for internal services.
+  # endpoints:
+  #   '/test':
+  #     target: 'https://example.com'
+  #     changeOrigin: true
+
+# Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  providers:
+    # See https://backstage.io/docs/auth/guest/provider
+    guest: {}
+
+scaffolder:
+  {}
+  # see https://backstage.io/docs/features/software-templates/configuration for software template options
+
+catalog:
+  import:
+    entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
+  rules:
+    - allow: [Component, System, API, Resource, Location]

--- a/tests/config/valid_rhdh_config.yaml
+++ b/tests/config/valid_rhdh_config.yaml
@@ -1,0 +1,85 @@
+app:
+  title: RHDH Lightspeed
+  baseUrl: http://localhost:3000
+
+organization:
+  name: Red Hat
+
+backend:
+  # Used for enabling authentication, secret is shared by all backend plugins
+  # See https://backstage.io/docs/auth/service-to-service-auth for
+  # information on the format
+  # auth:
+  #   keys:
+  #     - secret: ${BACKEND_SECRET}
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+    # Uncomment the following host directive to bind to specific interfaces
+    # host: 127.0.0.1
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+  cors:
+    origin: http://localhost:3000
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  # This is for local development only, it is not recommended to use this in production
+  # The production database configuration is stored in app-config.production.yaml
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
+
+integrations:
+  github:
+    - host: github.com
+      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
+      # about setting up the GitHub integration here: https://backstage.io/docs/integrations/github/locations#configuration
+      token: ${GITHUB_TOKEN}
+    ### Example for how to add your GitHub Enterprise instance using the API:
+    # - host: ghe.example.net
+    #   apiBaseUrl: https://ghe.example.net/api/v3
+    #   token: ${GHE_TOKEN}
+
+  ### Example for how to add a proxy endpoint for the frontend.
+  ### A typical reason to do this is to handle HTTPS and CORS for internal services.
+  # endpoints:
+  #   '/test':
+  #     target: 'https://example.com'
+  #     changeOrigin: true
+
+# Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  providers:
+    # See https://backstage.io/docs/auth/guest/provider
+    guest: {}
+
+scaffolder:
+  {}
+  # see https://backstage.io/docs/features/software-templates/configuration for software template options
+
+catalog:
+  import:
+    entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
+  rules:
+    - allow: [Component, System, API, Resource, Location]
+
+lightspeed:
+  servers:
+    - id: ollama
+      url: http://localhost:11434/v1
+      token: dummy-token

--- a/tests/config/valid_rhdh_config_multiple_providers.yaml
+++ b/tests/config/valid_rhdh_config_multiple_providers.yaml
@@ -1,0 +1,92 @@
+app:
+  title: RHDH Lightspeed
+  baseUrl: http://localhost:3000
+
+organization:
+  name: Red Hat
+
+backend:
+  # Used for enabling authentication, secret is shared by all backend plugins
+  # See https://backstage.io/docs/auth/service-to-service-auth for
+  # information on the format
+  # auth:
+  #   keys:
+  #     - secret: ${BACKEND_SECRET}
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+    # Uncomment the following host directive to bind to specific interfaces
+    # host: 127.0.0.1
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+  cors:
+    origin: http://localhost:3000
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  # This is for local development only, it is not recommended to use this in production
+  # The production database configuration is stored in app-config.production.yaml
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
+
+integrations:
+  github:
+    - host: github.com
+      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
+      # about setting up the GitHub integration here: https://backstage.io/docs/integrations/github/locations#configuration
+      token: ${GITHUB_TOKEN}
+    ### Example for how to add your GitHub Enterprise instance using the API:
+    # - host: ghe.example.net
+    #   apiBaseUrl: https://ghe.example.net/api/v3
+    #   token: ${GHE_TOKEN}
+
+  ### Example for how to add a proxy endpoint for the frontend.
+  ### A typical reason to do this is to handle HTTPS and CORS for internal services.
+  # endpoints:
+  #   '/test':
+  #     target: 'https://example.com'
+  #     changeOrigin: true
+
+# Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  providers:
+    # See https://backstage.io/docs/auth/guest/provider
+    guest: {}
+
+scaffolder:
+  {}
+  # see https://backstage.io/docs/features/software-templates/configuration for software template options
+
+catalog:
+  import:
+    entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
+  rules:
+    - allow: [Component, System, API, Resource, Location]
+
+lightspeed:
+  servers:
+    - id: ollama
+      url: http://localhost:11434/v1
+      token: dummy-token
+      models:
+        - name: model-one
+    - id: new-cluster
+      url: http://localhost:8080
+      token: my-token
+      models:
+        - name: model-one

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4,6 +4,7 @@ import copy
 import logging
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 import ols.utils.tls as tls
@@ -3589,3 +3590,145 @@ def test_ols_config_with_non_readable_system_prompt(tmpdir):
                 "system_prompt_path": "tests/config/",
             }
         )
+
+
+def test_missing_lightspeed_id_attribute():
+    """Test if missing id attribute is handled correctly."""
+    config = LLMProviders()
+    data = [
+        {
+            "url": "lightspeed-url",
+            "models": [{"name": "lightspeed-model-name"}],
+            "type": "lightspeed-type",
+            "token": "lightspeed-token",
+        }
+    ]
+
+    with pytest.raises(KeyError, match="lightspeed id is missing."):
+        config._parse_rhdh_lightspeed_config(data)
+
+
+def test_missing_lightspeed_url_attribute():
+    """Test if missing url attribute is handled correctly."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "models": [{"name": "lightspeed-model-name"}],
+            "type": "lightspeed-type",
+            "token": "lightspeed-token",
+        }
+    ]
+    with pytest.raises(KeyError, match="lightspeed url is missing."):
+        config._parse_rhdh_lightspeed_config(data)
+
+
+def test_missing_lightspeed_models_attribute():
+    """Test if missing model name attribute is handled correctly."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "url": "lightspeed-url",
+            "type": "lightspeed-type",
+            "token": "lightspeed-token",
+        }
+    ]
+    with pytest.raises(KeyError, match="lightspeed models missing."):
+        config._parse_rhdh_lightspeed_config(data)
+
+
+def test_missing_lightspeed_token_attribute():
+    """Test if missing token attribute is handled correctly."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "url": "lightspeed-url",
+            "models": [{"name": "lightspeed-model-name"}],
+            "type": "lightspeed-type",
+        }
+    ]
+    with pytest.raises(KeyError, match="lightspeed token is missing."):
+        config._parse_rhdh_lightspeed_config(data)
+
+
+def test_missing_lightspeed_type_attribute():
+    """Test if the missing type attribute is correctly handled."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "url": "lightspeed-url",
+            "models": [{"name": "lightspeed-model-name"}],
+            "token": "lightspeed-token",
+        }
+    ]
+    parsed_providers = config._parse_rhdh_lightspeed_config(data)
+    fetched_type = parsed_providers[0].type
+    assert fetched_type is not None and fetched_type == "openai"
+
+
+def test_lightspeed_token_setting():
+    """Test if the token is properly set for a lightspeed provider."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "url": "lightspeed-url",
+            "models": [{"name": "lightspeed-model-name"}],
+            "token": "lightspeed-token",
+            "type": "openai",
+        }
+    ]
+
+    parsed_providers = config._parse_rhdh_lightspeed_config(data)
+    assert (
+        parsed_providers[0].credentials is not None
+        and parsed_providers[0].credentials == "lightspeed-token"
+    )
+
+
+def test_lightspeed_config_parsing():
+    """Test if the parsing of lightspeed providers from an RHDH config file is handled properly."""
+    provider_one = ProviderConfig(
+        {
+            "name": "ollama",
+            "url": "http://localhost:11434/v1",
+            "models": [{"name": "model-one"}],
+            "type": "openai",
+        },
+        True,
+    )
+    provider_two = ProviderConfig(
+        {
+            "name": "new-cluster",
+            "url": "http://localhost:8080",
+            "models": [{"name": "model-one"}],
+            "type": "openai",
+        },
+        True,
+    )
+    provider_one.credentials = "dummy-token"
+    provider_two.credentials = "my-token"
+
+    expected_providers = {"ollama": provider_one, "new-cluster": provider_two}
+
+    config = LLMProviders()
+    with open(
+        "tests/config/valid_rhdh_config_multiple_providers.yaml", encoding="utf-8"
+    ) as f:
+        data = yaml.safe_load(f)
+        config.add_lightspeed_providers(data)
+
+    assert config.providers == expected_providers
+
+def test_lightspeed_config_parsing_empty():
+    """Test that is errors properly if there is no Lightspeed servers provided."""
+    with pytest.raises(KeyError):
+        config = LLMProviders()
+        with open(
+            "tests/config/invalid_rhdh_config.yaml", encoding="utf-8"
+        ) as f:
+            data = yaml.safe_load(f)
+            config.add_lightspeed_providers(data)

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -3723,12 +3723,11 @@ def test_lightspeed_config_parsing():
 
     assert config.providers == expected_providers
 
+
 def test_lightspeed_config_parsing_empty():
     """Test that is errors properly if there is no Lightspeed servers provided."""
     with pytest.raises(KeyError):
         config = LLMProviders()
-        with open(
-            "tests/config/invalid_rhdh_config.yaml", encoding="utf-8"
-        ) as f:
+        with open("tests/config/invalid_rhdh_config.yaml", encoding="utf-8") as f:
             data = yaml.safe_load(f)
             config.add_lightspeed_providers(data)

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -1,68 +1,76 @@
 """Unit tests for utility functions."""
-import re
-import pytest
-from ols.utils.checks import expand_lightspeed_environment_variables
 
 import os
+import re
 
-os.environ["TEST_TOKEN"] = "first-token"
-os.environ["TEST_TOKEN_TWO"] = "second-token"
+import pytest
 
-def test_expand_lightspeed_env_vars_failure():
+from ols.utils.checks import expands_lightspeed_environment_variables
+
+os.environ["TEST_TOKEN"] = "first-token"  # noqa: S105
+os.environ["TEST_TOKEN_TWO"] = "second-token"  # noqa: S105
+
+
+def test_expands_lightspeed_env_vars_failure():
     """Tests the expansion of Lightspeed environment variables that are unset."""
     data = [
         {
-            'id': 'test-id',
-            'url': 'https://localhost:8080',
-            'token': '${TEST_TOKEN_THREE}',
-            'models': [{"name": "test-model-name"}],
-            'type': 'openai'
+            "id": "test-id",
+            "url": "https://localhost:8080",
+            "token": "${TEST_TOKEN_THREE}",
+            "models": [{"name": "test-model-name"}],
+            "type": "openai",
         },
         {
-            'id': 'second-test-id',
-            'url': 'https://localhost:6060',
-            'token': 'token',
-            'models': [{"name": "test-name"}],
-            'type': 'openai'
-        }
+            "id": "second-test-id",
+            "url": "https://localhost:6060",
+            "token": "token",
+            "models": [{"name": "test-name"}],
+            "type": "openai",
+        },
     ]
-    with pytest.raises(Exception, match=re.escape("Environment variable referenced but not set. ${TEST_TOKEN_THREE}")):
-        expand_lightspeed_environment_variables(data)
+    with pytest.raises(
+        Exception,
+        match=re.escape(
+            "Environment variable referenced but not set. ${TEST_TOKEN_THREE}"
+        ),
+    ):
+        expands_lightspeed_environment_variables(data)
 
 
-def test_expand_lightspeed_env_vars_success():
+def test_expands_lightspeed_env_vars_success():
     """Tests the ability to expand environment variables into Python dictionaries."""
     data = [
         {
-            'id': 'test-id',
-            'url': 'https://localhost:8080',
-            'token': '${TEST_TOKEN}',
-            'models': [{"name": "test-model-name"}],
-            'type': 'openai'
+            "id": "test-id",
+            "url": "https://localhost:8080",
+            "token": "${TEST_TOKEN}",
+            "models": [{"name": "test-model-name"}],
+            "type": "openai",
         },
         {
-            'id': 'second-test-id',
-            'url': 'https://localhost:6060',
-            'token': '${TEST_TOKEN_TWO}',
-            'models': [{"name": "expected-model-name"}],
-            'type': 'openai'
-        }
+            "id": "second-test-id",
+            "url": "https://localhost:6060",
+            "token": "${TEST_TOKEN_TWO}",
+            "models": [{"name": "expected-model-name"}],
+            "type": "openai",
+        },
     ]
     expected_data = [
         {
-            'id': 'test-id',
-            'url': 'https://localhost:8080',
-            'token': 'first-token',
-            'models': [{"name": "test-model-name"}],
-            'type': 'openai'
+            "id": "test-id",
+            "url": "https://localhost:8080",
+            "token": "first-token",
+            "models": [{"name": "test-model-name"}],
+            "type": "openai",
         },
         {
-            'id': 'second-test-id',
-            'url': 'https://localhost:6060',
-            'token': 'second-token',
-            'models': [{"name": "expected-model-name"}],
-            'type': 'openai'
-        }
+            "id": "second-test-id",
+            "url": "https://localhost:6060",
+            "token": "second-token",
+            "models": [{"name": "expected-model-name"}],
+            "type": "openai",
+        },
     ]
-    expand_lightspeed_environment_variables(data)
+    expands_lightspeed_environment_variables(data)
     assert data == expected_data

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -1,0 +1,68 @@
+"""Unit tests for utility functions."""
+import re
+import pytest
+from ols.utils.checks import expand_lightspeed_environment_variables
+
+import os
+
+os.environ["TEST_TOKEN"] = "first-token"
+os.environ["TEST_TOKEN_TWO"] = "second-token"
+
+def test_expand_lightspeed_env_vars_failure():
+    """Tests the expansion of Lightspeed environment variables that are unset."""
+    data = [
+        {
+            'id': 'test-id',
+            'url': 'https://localhost:8080',
+            'token': '${TEST_TOKEN_THREE}',
+            'models': [{"name": "test-model-name"}],
+            'type': 'openai'
+        },
+        {
+            'id': 'second-test-id',
+            'url': 'https://localhost:6060',
+            'token': 'token',
+            'models': [{"name": "test-name"}],
+            'type': 'openai'
+        }
+    ]
+    with pytest.raises(Exception, match=re.escape("Environment variable referenced but not set. ${TEST_TOKEN_THREE}")):
+        expand_lightspeed_environment_variables(data)
+
+
+def test_expand_lightspeed_env_vars_success():
+    """Tests the ability to expand environment variables into Python dictionaries."""
+    data = [
+        {
+            'id': 'test-id',
+            'url': 'https://localhost:8080',
+            'token': '${TEST_TOKEN}',
+            'models': [{"name": "test-model-name"}],
+            'type': 'openai'
+        },
+        {
+            'id': 'second-test-id',
+            'url': 'https://localhost:6060',
+            'token': '${TEST_TOKEN_TWO}',
+            'models': [{"name": "expected-model-name"}],
+            'type': 'openai'
+        }
+    ]
+    expected_data = [
+        {
+            'id': 'test-id',
+            'url': 'https://localhost:8080',
+            'token': 'first-token',
+            'models': [{"name": "test-model-name"}],
+            'type': 'openai'
+        },
+        {
+            'id': 'second-test-id',
+            'url': 'https://localhost:6060',
+            'token': 'second-token',
+            'models': [{"name": "expected-model-name"}],
+            'type': 'openai'
+        }
+    ]
+    expand_lightspeed_environment_variables(data)
+    assert data == expected_data

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1441,3 +1441,21 @@ def test_valid_config_with_watsonx_credentials_path_only_in_provider_config():
     except Exception as e:
         print(traceback.format_exc())
         pytest.fail(f"loading valid configuration failed: {e}")
+
+
+def test_missing_additional_config_file():
+    """Check how missing an additional configuration file is handled."""
+    with pytest.raises(Exception, match="Not a directory"):
+        # /dev/null is special file so it can't be directory
+        # at the same moment
+        config.reload_additional_config_file("/dev/null/non-existent", "")
+
+
+def test_additional_config_file_incorrect_type():
+    """Check how an additional configuration file is handled with an incorrect type."""
+    with pytest.raises(
+        ValueError, match="Configuration file type 'wrongtype' not recognized."
+    ):
+        config.reload_additional_config_file(
+            "tests/config/valid_rhdh_config.yaml", "wrongtype"
+        )


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds the ability to load an additional configuration file alongside the `RCS_CONFIG_FILE`. This change currently supports the RHDH config map responsible for containing OLS plugin information, but can be extended to any additional configuration files. The file can be loaded and referenced similar to RCS through the `RHDH_CONFIG_FILE` environment variable.

The proposed change will grab all OLS related data and attempt to add providers defined in RHDH to RCS. These providers can then be used when hitting the `/query` endpoint.

You can find a demo overview of this change here: https://drive.google.com/file/d/1XDWqnSA7-Mz5hppiDAgDcIoYfNou3Tfn/view?usp=sharing

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue https://github.com/road-core/service/issues/335
- Closes https://github.com/road-core/service/issues/335
- JIRA https://issues.redhat.com/browse/RHDHPAI-528

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
