### PR TITLE
message.content error solved

### DIFF
--- a/ols/src/prompts/prompt_generator.py
+++ b/ols/src/prompts/prompt_generator.py
@@ -43,9 +43,9 @@ def restructure_history(message: BaseMessage, model: str) -> BaseMessage:
     new_message = copy(message)
     # Granite specific formatting for history
     if isinstance(message, HumanMessage):
-        new_message.content = "\n<|user|>\n" + message.content
+        new_message.content = "\n<|user|>\n" + (message.content if isinstance(message.content, str) else str(message.content))
     else:
-        new_message.content = "\n<|assistant|>\n" + message.content
+        new_message.content = "\n<|assistant|>\n" + (message.content if isinstance(message.content, str) else str(message.content))
     return new_message
 
 
@@ -112,7 +112,7 @@ class GeneratePrompt:
             )
             llm_input_values["chat_history"] = ""
             for message in self._history:
-                llm_input_values["chat_history"] += message.content
+                llm_input_values["chat_history"] += (message.content if isinstance(message.content, str) else str(message.content))
 
         if "context" in llm_input_values:
             prompt_message = prompt_message + "\n{context}"


### PR DESCRIPTION
## Description

In ols/src/prompts/prompt_generator.py
At line 46, 48 and 115 message.content was creating problem as in the definition of basemessage, it can be of type str as well as list of str and dict. So performing direct concatination with str was problematic. So I added if condition to add as message.content if message.content is string else it will change it to str and then add.

## Type of change
- Bug fix

## Related Tickets & Documents

- Related Issue #361

