### PR TITLE
DNM PoC for gradual removal of Langchain

### DIFF
--- a/tests/mock_classes/mock_llm_loader.py
+++ b/tests/mock_classes/mock_llm_loader.py
@@ -19,6 +19,10 @@ class MockLLMLoader:
         # yield input prompt/user query
         yield llm_input[1].content
 
+    def invoke(self, input, config=None, **kwargs):  # noqa: A002,W0622,RUF100
+        """Transform a single input into an output."""
+        return input
+
 
 def mock_llm_loader(llm=None, expected_params=None):
     """Construct mock for load_llm."""

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -1,7 +1,5 @@
 """Unit tests for QuestionValidator class."""
 
-from unittest.mock import patch
-
 import pytest
 
 from ols import config
@@ -14,7 +12,6 @@ from ols.src.query_helpers.question_validator import (  # noqa: E402
     QueryHelper,
     QuestionValidator,
 )
-from tests.mock_classes.mock_llm_chain import mock_llm_chain  # noqa: E402
 from tests.mock_classes.mock_llm_loader import mock_llm_loader  # noqa: E402
 
 
@@ -63,7 +60,6 @@ def test_passing_parameters():
     )
 
 
-@patch("ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None))
 def test_validate_question_llm_loader():
     """Test that LLM is loaded within validate_question method with proper parameters."""
     # it is needed to initialize configuration in order to be able


### PR DESCRIPTION
## Description

The PR is not meant to be merged, it is only meant to demonstrate how we could gradually remove Langchain API from the code. The `PromptTemplate` can be replaced with simple replace call on a string object. The chain itself can be replaced with a bare LLM model.

This still involves Langchain during the model call, but it doesn't involve as many abstractions. Further improvement would be to replace LLM object from Langhchain with a simple wrapper for REST API calls.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
