### PR TITLE
Refactoring the data collector script

### DIFF
--- a/docs/user_data_flow.uml
+++ b/docs/user_data_flow.uml
@@ -35,7 +35,7 @@ ols -> disk: Store feedback as JSON
 sidecar -> disk: Scan for new JSON files
 disk -> sidecar: New JSON files
 sidecar -> sidecar: Package data into tar.gz
-sidecar -> ingress: Upload ols.tgz
+sidecar -> ingress: Upload rcs.tgz
 
 == Data Processing ==
 ingress -> cs: Forward data

--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -97,6 +97,7 @@ ols_config:
     feedback_storage: "/tmp/data/feedback"
     transcripts_disabled: false
     transcripts_storage: "/tmp/data/transcripts"
+    ingress_url: "https://example.ingress.com/"
   tls_config:
     tls_certificate_path: /app-root/certs/certificate.crt
     tls_key_path: /app-root/certs/private.key

--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -97,7 +97,7 @@ ols_config:
     feedback_storage: "/tmp/data/feedback"
     transcripts_disabled: false
     transcripts_storage: "/tmp/data/transcripts"
-    ingress_url: "https://example.ingress.com/"
+    ingress_url: "https://example.ingress.com/upload"
   tls_config:
     tls_certificate_path: /app-root/certs/certificate.crt
     tls_key_path: /app-root/certs/private.key

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1167,9 +1167,8 @@ class UserDataCollectorConfig(BaseModel):
     ingress_base_delay: int = 60  # exponential backoff parameter
     ingress_max_retries: int = 3  # exponential backoff parameter
     access_token_generation_timeout: int = 5
-    user_agent: str = (
-        "openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}"
-    )
+    user_agent: str
+    user_data_max_size: int = 100 * 1024 * 1024  # 100 MiB
 
     def __init__(self, **data: Any) -> None:
         """Initialize configuration."""
@@ -1226,9 +1225,13 @@ class Config(BaseModel):
             )
         # Always initialize dev config, even if there's no config for it.
         self.dev_config = DevConfig(**data.get("dev_config", {}))
-        self.user_data_collector_config = UserDataCollectorConfig(
-            **data.get("user_data_collector_config", {})
-        )
+        if not (
+            self.ols_config.user_data_collection.feedback_disabled
+            and self.ols_config.user_data_collection.transcripts_disabled
+        ):
+            self.user_data_collector_config = UserDataCollectorConfig(
+                **data.get("user_data_collector_config", {})
+            )
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1160,7 +1160,7 @@ class UserDataCollectorConfig(BaseModel):
     log_level: int = logging.INFO
     collection_interval: int = 2 * 60 * 60  # 2 hours
     run_without_initial_wait: bool = False
-    ingress_url: AnyHttpUrl = constants.DEFAULT_INGRESS_URL
+    ingress_url: AnyHttpUrl = AnyHttpUrl(constants.DEFAULT_INGRESS_URL)
     cp_offline_token: Optional[str] = None
     initial_wait: int = 60 * 5  # 5 minutes in seconds
     ingress_timeout: int = 30

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1160,7 +1160,7 @@ class UserDataCollectorConfig(BaseModel):
     log_level: int = logging.INFO
     collection_interval: int = 2 * 60 * 60  # 2 hours
     run_without_initial_wait: bool = False
-    ingress_url: AnyHttpUrl
+    ingress_url: AnyHttpUrl = constants.DEFAULT_INGRESS_URL
     cp_offline_token: Optional[str] = None
     initial_wait: int = 60 * 5  # 5 minutes in seconds
     ingress_timeout: int = 30

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import re
-from typing import Any, Literal, Optional, Self
+from typing import Any, Optional, Self
 
 from pydantic import (
     AnyHttpUrl,
@@ -1160,7 +1160,7 @@ class UserDataCollectorConfig(BaseModel):
     log_level: int = logging.INFO
     collection_interval: int = 2 * 60 * 60  # 2 hours
     run_without_initial_wait: bool = False
-    ingress_env: Literal["stage", "prod"] = "prod"
+    ingress_url: AnyHttpUrl
     cp_offline_token: Optional[str] = None
     initial_wait: int = 60 * 5  # 5 minutes in seconds
     ingress_timeout: int = 30
@@ -1177,18 +1177,6 @@ class UserDataCollectorConfig(BaseModel):
         if "log_level" in data:
             data["log_level"] = checks.get_log_level(data["log_level"])
         super().__init__(**data)
-
-    @model_validator(mode="after")
-    def validate_token_is_set_when_needed(self) -> Self:
-        """Check that cp_offline_token is set when env is stage."""
-        if self.ingress_env == "stage" and self.cp_offline_token is None:
-            raise ValueError("cp_offline_token is required in stage environment")
-        if "{cluster_id}" not in self.user_agent:
-            raise ValueError(
-                "user_agent must contain a {cluster_id} substring, "
-                "as a placeholder for k8s cluster ID"
-            )
-        return self
 
 
 class Config(BaseModel):

--- a/ols/constants.py
+++ b/ols/constants.py
@@ -237,3 +237,6 @@ class VectorStoreType(StrEnum):
 # quota limiters constants
 USER_QUOTA_LIMITER = "user_limiter"
 CLUSTER_QUOTA_LIMITER = "cluster_limiter"
+
+# URL for data collector ingress endpoint
+DEFAULT_INGRESS_URL = "https://console.redhat.com/api/ingress/v1/upload"

--- a/ols/user_data_collection/README.md
+++ b/ols/user_data_collection/README.md
@@ -76,7 +76,7 @@ user_data_collector_config:
   log_level: debug
   collection_interval: 10  # seconds
   run_without_initial_wait: true
-  ingress_env: stage
+  ingress_url: "https://sso.stage.redhat.com/"
   cp_offline_token: token
 ```
 

--- a/ols/user_data_collection/README.md
+++ b/ols/user_data_collection/README.md
@@ -76,13 +76,14 @@ user_data_collector_config:
   log_level: debug
   collection_interval: 10  # seconds
   run_without_initial_wait: true
-  ingress_url: "https://sso.stage.redhat.com/"
+  ingress_url: "https://example.ingress.com/upload"
   cp_offline_token: token
 ```
 
 - `data_storage`: Absolute path of directory containing /transcripts and/or /feedback with data.
 - `run_without_initial_wait`: Set to `true` to avoid waiting before collection (default is 5 minutes).
-- `cp_offline_token`: Offline token generated for the environment you desire.
+- `ingress_url`: URL of the chosen ingress endpoint.
+- `cp_offline_token`: Offline token generated for the ingress endpoint located at `ingress_url`.
 
 If you don't want to create the data manually, you can use OLS service to do it for you (as it does in production). You need relevant config entry
 ```yaml

--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -176,7 +176,7 @@ def upload_data_to_ingress(
     logger.info("sending collected data")
     payload = {
         "file": (
-            "ols.tgz",
+            "rcs.tgz",
             tarball.read(),
             "application/vnd.redhat.openshift.periodic+tar",
         ),

--- a/ols/user_data_collection/data_collector.py
+++ b/ols/user_data_collection/data_collector.py
@@ -16,7 +16,6 @@ import pathlib
 import sys
 import tarfile
 import time
-from collections.abc import Callable
 from typing import Any
 
 import kubernetes
@@ -27,35 +26,14 @@ sys.path.append(pathlib.Path(__file__).parent.parent.parent.as_posix())
 
 # initialize config
 from ols import config  # pylint: disable=C0413
+from ols.app.models.config import UserDataCollectorConfig  # pylint: disable=C0413
 from ols.constants import (  # pylint: disable=C0413
     CONFIGURATION_FILE_NAME_ENV_VARIABLE,
     DEFAULT_CONFIGURATION_FILE,
 )
 
-OLS_USER_DATA_MAX_SIZE = 100 * 1024 * 1024  # 100 MiB
-
-cfg_file = os.environ.get(
-    CONFIGURATION_FILE_NAME_ENV_VARIABLE, DEFAULT_CONFIGURATION_FILE
-)
-config.reload_from_yaml_file(
-    cfg_file, ignore_llm_secrets=True, ignore_missing_certs=True
-)
-udc_config = config.user_data_collector_config  # shortcut
-
-
 # pylint: disable-next=C0413
-from ols.src.auth.k8s import K8sClientSingleton  # noqa: E402
-
-logging.basicConfig(
-    level=udc_config.log_level,
-    stream=sys.stdout,
-    format="[%(asctime)s] %(levelname)s: %(message)s",
-)
-# silence libs logging
-# - urllib3 - we don't care about those debug posts
-# - kubernetes - prints resources content when debug, causing secrets leak
-logging.getLogger("kubernetes").setLevel(logging.WARNING)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
+from ols.src.auth.k8s import K8sClientSingleton
 
 logger = logging.getLogger(__name__)
 
@@ -68,15 +46,17 @@ class ClusterIDNotFoundError(Exception):
     """Cluster id is not found."""
 
 
-def get_ingress_upload_url() -> str:
+def get_ingress_upload_url(ingress_env: str) -> str:
     """Get the Ingress upload URL based on the environment."""
     upload_endpoint = "api/ingress/v1/upload"
-    if udc_config.ingress_env == "prod":
+    if ingress_env == "prod":
         return "https://console.redhat.com/" + upload_endpoint
     return "https://console.stage.redhat.com/" + upload_endpoint
 
 
-def access_token_from_offline_token(offline_token: str) -> str:
+def access_token_from_offline_token(
+    offline_token: str, ingress_env: str, access_token_generation_timeout: int
+) -> str:
     """Generate "access token" from the "offline token".
 
     Offline token can be generated at:
@@ -85,11 +65,12 @@ def access_token_from_offline_token(offline_token: str) -> str:
 
     Args:
         offline_token: Offline token from the Customer Portal.
-
+        ingress_env: chosen ingress environment
+        access_token_generation_timeout: timeout for access token, in seconds
     Returns:
         Refresh token.
     """
-    if udc_config.ingress_env == "prod":
+    if ingress_env == "prod":
         url = "https://sso.redhat.com/"
     else:
         url = "https://sso.stage.redhat.com/"
@@ -101,7 +82,7 @@ def access_token_from_offline_token(offline_token: str) -> str:
     }
 
     response = requests.post(
-        url + endpoint, data=data, timeout=udc_config.access_token_generation_timeout
+        url + endpoint, data=data, timeout=access_token_generation_timeout
     )
     try:
         if response.status_code == requests.codes.ok:
@@ -190,45 +171,22 @@ def package_files_into_tarball(
     return tarball_io
 
 
-def exponential_backoff_decorator(max_retries: int, base_delay: int) -> Callable:
-    """Exponential backoff decorator."""
+def upload_data_to_ingress(
+    tarball: io.BytesIO, udc_config: UserDataCollectorConfig
+) -> requests.Response:
+    """Attempt to upload the tarball to a Ingress.
 
-    def decorator(func: Callable) -> Callable:
-        def wrapper(*args: Any, **kwargs: Any) -> None:
-            retries = 0
-            while retries < max_retries:
-                try:
-                    func(*args, **kwargs)
-                    return
-                except Exception as e:
-                    logger.error(
-                        "attempt %d failed with error: %s", retries + 1, str(e)
-                    )
-                    retries += 1
-                    delay = base_delay * 2**retries
-                    logger.info("retrying in %d seconds...", delay)
-                    time.sleep(delay)
-            logger.error("max retries reached, operation failed.")
-
-        return wrapper
-
-    return decorator
-
-
-@exponential_backoff_decorator(
-    max_retries=udc_config.ingress_max_retries, base_delay=udc_config.ingress_base_delay
-)
-def upload_data_to_ingress(tarball: io.BytesIO) -> requests.Response:
-    """Upload the tarball to a Ingress.
+    If upload fails, for any reason, another attempt is made, with delay
+    and number of repetitions set in the `udc_config`.
 
     Args:
         tarball: BytesIO object representing the tarball to be uploaded.
-
+        udc_config: Configuration for the data collector
     Returns:
         Response object from the Ingress.
     """
     logger.info("sending collected data")
-    url = get_ingress_upload_url()
+    url = get_ingress_upload_url(udc_config.ingress_env)
     payload = {
         "file": (
             "ols.tgz",
@@ -239,42 +197,58 @@ def upload_data_to_ingress(tarball: io.BytesIO) -> requests.Response:
 
     headers: dict[str, str | bytes]
 
-    if udc_config.cp_offline_token:
-        logger.debug("using CP offline token to generate refresh token")
-        token = access_token_from_offline_token(udc_config.cp_offline_token)
-        # when authenticating with token, user-agent is not accepted
-        # causing "UHC services authentication failed"
-        headers = {"Authorization": f"Bearer {token}"}
-    else:
-        logger.debug("using cluster pull secret to authenticate")
-        cluster_id = K8sClientSingleton.get_cluster_id()
-        token = get_cloud_openshift_pull_secret()
-        headers = {
-            "User-Agent": udc_config.user_agent.format(cluster_id=cluster_id),
-            "Authorization": f"Bearer {token}",
-        }
+    retries = 0
+    while retries < udc_config.ingress_max_retries:
+        try:
+            if udc_config.cp_offline_token:
+                logger.debug("using CP offline token to generate refresh token")
+                token = access_token_from_offline_token(
+                    udc_config.cp_offline_token,
+                    udc_config.ingress_env,
+                    udc_config.access_token_generation_timeout,
+                )
+                # when authenticating with token, user-agent is not accepted
+                # causing "UHC services authentication failed"
+                headers = {"Authorization": f"Bearer {token}"}
+            else:
+                logger.debug("using cluster pull secret to authenticate")
+                cluster_id = K8sClientSingleton.get_cluster_id()
+                token = get_cloud_openshift_pull_secret()
+                headers = {
+                    "User-Agent": udc_config.user_agent.format(cluster_id=cluster_id),
+                    "Authorization": f"Bearer {token}",
+                }
 
-    with requests.Session() as s:
-        s.headers = headers
-        logger.debug("posting payload to %s", url)
-        response = s.post(
-            url=url,
-            files=payload,
-            timeout=udc_config.ingress_timeout,
-        )
+            with requests.Session() as s:
+                s.headers = headers
+                logger.debug("posting payload to %s", url)
+                response = s.post(
+                    url=url,
+                    files=payload,
+                    timeout=udc_config.ingress_timeout,
+                )
 
-    if response.status_code != requests.codes.accepted:
-        logger.error(
-            "posting payload failed, response: %d: %s",
-            response.status_code,
-            response.text,
-        )
-        raise requests.exceptions.HTTPError(
-            f"data upload failed with response code: {response.status_code}"
-        )
+            if response.status_code != requests.codes.accepted:
+                logger.error(
+                    "posting payload failed, response: %d: %s",
+                    response.status_code,
+                    response.text,
+                )
+                raise requests.exceptions.HTTPError(
+                    f"data upload failed with response code: {response.status_code}"
+                )
 
-    request_id = response.json()["request_id"]
-    logger.info("data uploaded with request_id: '%s'", request_id)
+            request_id = response.json()["request_id"]
+            logger.info("data uploaded with request_id: '%s'", request_id)
+
+        except Exception as e:
+            logger.error("attempt %d failed with error: %s", retries + 1, str(e))
+            retries += 1
+            delay = udc_config.ingress_base_delay * 2**retries
+            logger.info("retrying in %d seconds...", delay)
+            time.sleep(delay)
+
+    logger.error("max retries reached, operation failed.")
 
     return response
 
@@ -293,7 +267,7 @@ def delete_data(file_paths: list[pathlib.Path]) -> None:
 
 
 def chunk_data(
-    data: list[pathlib.Path], chunk_max_size: int = OLS_USER_DATA_MAX_SIZE
+    data: list[pathlib.Path], chunk_max_size: int
 ) -> list[list[pathlib.Path]]:
     """Chunk the data into smaller parts.
 
@@ -323,23 +297,25 @@ def chunk_data(
     return chunks
 
 
-def gather_ols_user_data(data_path: str) -> None:
+def gather_ols_user_data(udc_config: UserDataCollectorConfig) -> None:
     """Gather OLS user data and upload it to the Ingress service."""
-    collected_files = collect_ols_data_from(data_path)
-    data_chunks = chunk_data(collected_files)
+    collected_files = collect_ols_data_from(udc_config.data_storage.as_posix())
+    data_chunks = chunk_data(collected_files, udc_config.user_data_max_size)
     if any(data_chunks):
         logger.info(
             "collected %d files (splitted to %d chunks) from '%s'",
             len(collected_files),
             len(data_chunks),
-            data_path,
+            udc_config.data_storage.as_posix(),
         )
         logger.debug("collected files: %s", collected_files)
         for i, data_chunk in enumerate(data_chunks):
             logger.info("uploading data chunk %d/%d", i + 1, len(data_chunks))
-            tarball = package_files_into_tarball(data_chunk, path_to_strip=data_path)
+            tarball = package_files_into_tarball(
+                data_chunk, path_to_strip=udc_config.data_storage.as_posix()
+            )
             try:
-                upload_data_to_ingress(tarball)
+                upload_data_to_ingress(tarball, udc_config)
                 delete_data(data_chunk)
                 logger.info("uploaded data removed")
             except (ClusterPullSecretNotFoundError, ClusterIDNotFoundError) as e:
@@ -350,12 +326,15 @@ def gather_ols_user_data(data_path: str) -> None:
             # close the tarball to release mem
             tarball.close()
     else:
-        logger.info("'%s' contains no data, nothing to do...", data_path)
+        logger.info(
+            "'%s' contains no data, nothing to do...",
+            udc_config.data_storage.as_posix(),
+        )
 
 
 def ensure_data_dir_is_not_bigger_than_defined(
-    data_dir: str = udc_config.data_storage.as_posix(),
-    max_size: int = OLS_USER_DATA_MAX_SIZE,
+    data_dir: str,
+    max_size: int,
 ) -> None:
     """Ensure that the data dir is not bigger than it should be.
 
@@ -383,21 +362,41 @@ def ensure_data_dir_is_not_bigger_than_defined(
 # NOTE: This condition is here mainly to have a way how to influence
 # when the collector is running in the e2e tests. It is not meant to be
 # used in the production.
-def disabled_by_file() -> bool:
+def disabled_by_file(data_storage: pathlib.Path) -> bool:
     """Check if the data collection is disabled by a file.
 
     Pure existence of the file `disable_collector` in the root of the
     user data dir is enough to disable the data collection.
     """
-    if udc_config.data_storage is None:
+    if data_storage is None:
         logger.warning(
             "Data storage path is None, cannot check for disable_collector file."
         )
         return False
-    return (udc_config.data_storage / "disable_collector").exists()
+    return (data_storage / "disable_collector").exists()
 
 
 if __name__ == "__main__":
+
+    cfg_file = os.environ.get(
+        CONFIGURATION_FILE_NAME_ENV_VARIABLE, DEFAULT_CONFIGURATION_FILE
+    )
+    config.reload_from_yaml_file(
+        cfg_file, ignore_llm_secrets=True, ignore_missing_certs=True
+    )
+    udc_config = config.user_data_collector_config  # shortcut
+
+    logging.basicConfig(
+        level=udc_config.log_level,
+        stream=sys.stdout,
+        format="[%(asctime)s] %(levelname)s: %(message)s",
+    )
+    # silence libs logging
+    # - urllib3 - we don't care about those debug posts
+    # - kubernetes - prints resources content when debug, causing secrets leak
+    logging.getLogger("kubernetes").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     if not udc_config.run_without_initial_wait:
         logger.info(
             "collection script started, waiting %d seconds before first collection",
@@ -405,9 +404,11 @@ if __name__ == "__main__":
         )
         time.sleep(udc_config.initial_wait)
     while True:
-        if not disabled_by_file():
+        if not disabled_by_file(udc_config.data_storage):
             gather_ols_user_data(udc_config.data_storage.as_posix())
-            ensure_data_dir_is_not_bigger_than_defined()
+            ensure_data_dir_is_not_bigger_than_defined(
+                udc_config.data_storage.as_posix(), udc_config.user_data_max_size
+            )
         else:
             logger.info("disabled by control file, skipping data collection")
         time.sleep(udc_config.collection_interval)

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -41,3 +41,5 @@ ols_config:
 dev_config:
   disable_auth: true
   disable_tls: true
+user_data_collector_config:
+  user_agent: "lightspeed-operator/user-data-collection cluster/{cluster_id}"

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -43,3 +43,4 @@ dev_config:
   disable_tls: true
 user_data_collector_config:
   user_agent: "lightspeed-operator/user-data-collection cluster/{cluster_id}"
+  ingress_url: "https://sso.redhat.com/"

--- a/tests/config/valid_config.yaml
+++ b/tests/config/valid_config.yaml
@@ -43,4 +43,4 @@ dev_config:
   disable_tls: true
 user_data_collector_config:
   user_agent: "lightspeed-operator/user-data-collection cluster/{cluster_id}"
-  ingress_url: "https://sso.redhat.com/"
+  ingress_url: "https://example.ingress.com/upload"

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -3542,13 +3542,13 @@ def test_user_data_collection_config__defaults():
     """Test the UserDataCollection model with default values."""
     udc_config = UserDataCollectorConfig(
         user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
-        ingress_url="https://sso.redhat.com/",
+        ingress_url="https://example.ingress.com/upload",
     )
     assert udc_config.data_storage is None
     assert udc_config.log_level == logging.INFO
     assert udc_config.collection_interval == 2 * 60 * 60
     assert udc_config.run_without_initial_wait is False
-    assert udc_config.ingress_url == AnyHttpUrl("https://sso.redhat.com/")
+    assert udc_config.ingress_url == AnyHttpUrl("https://example.ingress.com/upload")
     assert udc_config.cp_offline_token is None
 
 
@@ -3557,14 +3557,14 @@ def test_user_data_collection_config__logging_level():
     udc_config = UserDataCollectorConfig(
         log_level="debug",
         user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
-        ingress_url="https://sso.redhat.com/",
+        ingress_url="https://example.ingress.com/upload",
     )
     assert udc_config.log_level == logging.DEBUG
 
     udc_config = UserDataCollectorConfig(
         log_level="DEBUG",
         user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
-        ingress_url="https://sso.redhat.com/",
+        ingress_url="https://example.ingress.com/upload",
     )
     assert udc_config.log_level == logging.DEBUG
 

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -2510,7 +2510,7 @@ def test_config():
         config.ols_config.query_validation_method
         == constants.QueryValidationMethod.DISABLED
     )
-    assert config.user_data_collector_config == UserDataCollectorConfig()
+    assert config.user_data_collector_config is None
     assert config.ols_config.certificate_directory == "/foo/bar/baz"
     assert config.ols_config.system_prompt_path is None
     assert config.ols_config.system_prompt is None
@@ -3540,7 +3540,9 @@ def test_dev_config_bool_inputs():
 
 def test_user_data_collection_config__defaults():
     """Test the UserDataCollection model with default values."""
-    udc_config = UserDataCollectorConfig()
+    udc_config = UserDataCollectorConfig(
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}"
+    )
     assert udc_config.data_storage is None
     assert udc_config.log_level == logging.INFO
     assert udc_config.collection_interval == 2 * 60 * 60
@@ -3551,10 +3553,16 @@ def test_user_data_collection_config__defaults():
 
 def test_user_data_collection_config__logging_level():
     """Test the UserDataCollection model with logging level."""
-    udc_config = UserDataCollectorConfig(log_level="debug")
+    udc_config = UserDataCollectorConfig(
+        log_level="debug",
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
+    )
     assert udc_config.log_level == logging.DEBUG
 
-    udc_config = UserDataCollectorConfig(log_level="DEBUG")
+    udc_config = UserDataCollectorConfig(
+        log_level="DEBUG",
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
+    )
     assert udc_config.log_level == logging.DEBUG
 
 
@@ -3563,6 +3571,7 @@ def test_user_data_collection_config__token_expectation():
     udc_config = UserDataCollectorConfig(
         ingress_env="stage",
         cp_offline_token="123",  # noqa: S106
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
     )
     assert udc_config.ingress_env == "stage"
     assert udc_config.cp_offline_token == "123"  # noqa: S105
@@ -3571,7 +3580,11 @@ def test_user_data_collection_config__token_expectation():
         ValueError,
         match="cp_offline_token is required in stage environment",
     ):
-        UserDataCollectorConfig(ingress_env="stage", cp_offline_token=None)
+        UserDataCollectorConfig(
+            ingress_env="stage",
+            cp_offline_token=None,
+            user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
+        )
 
 
 def test_ols_config_with_system_prompt(tmpdir):

--- a/tests/unit/user_data_collection/test_data_collector.py
+++ b/tests/unit/user_data_collection/test_data_collector.py
@@ -19,7 +19,8 @@ from ols.utils import suid
 def mock_data_collector_config(tmp_path):
     """Mock UserDataCollectorConfig file with valid path."""
     udc_config = UserDataCollectorConfig(
-        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}"
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
+        ingress_url="https://sso.redhat.com/",
     )
     udc_config.data_storage = pathlib.Path(tmp_path)
     return udc_config

--- a/tests/unit/user_data_collection/test_data_collector.py
+++ b/tests/unit/user_data_collection/test_data_collector.py
@@ -20,7 +20,7 @@ def mock_data_collector_config(tmp_path):
     """Mock UserDataCollectorConfig file with valid path."""
     udc_config = UserDataCollectorConfig(
         user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}",
-        ingress_url="https://sso.redhat.com/",
+        ingress_url="https://example.ingress.com/upload",
     )
     udc_config.data_storage = pathlib.Path(tmp_path)
     return udc_config

--- a/tests/unit/user_data_collection/test_data_collector.py
+++ b/tests/unit/user_data_collection/test_data_collector.py
@@ -9,24 +9,20 @@ from unittest.mock import Mock, patch
 import pytest
 from requests.models import Response
 
+from ols.app.models.config import UserDataCollectorConfig
+from ols.user_data_collection import data_collector
+from ols.user_data_collection.data_collector import collect_ols_data_from
 from ols.utils import suid
 
 
-@pytest.fixture(scope="module", autouse=True)
-def with_mocked_config():
-    """Run test with mocked config.
-
-    We don't need that for unit tests.
-    """
-    global data_collector
-    global original_collect_ols_data_from
-    with patch("ols.config", new=Mock()):
-        from ols.user_data_collection import data_collector
-        from ols.user_data_collection.data_collector import (
-            collect_ols_data_from as original_collect_ols_data_from,
-        )
-
-        yield
+@pytest.fixture
+def mock_data_collector_config(tmp_path):
+    """Mock UserDataCollectorConfig file with valid path."""
+    udc_config = UserDataCollectorConfig(
+        user_agent="openshift-lightspeed-operator/user-data-collection cluster/{cluster_id}"
+    )
+    udc_config.data_storage = pathlib.Path(tmp_path)
+    return udc_config
 
 
 def mock_ingress_response(*args, **kwargs):
@@ -112,7 +108,7 @@ def test_delete_data(tmp_path):
 def mock_collect_ols_data_from(data_path: str) -> list[pathlib.Path]:
     """Mock collect_ols_data_from function."""
     # call the original function and get its result
-    original_result = original_collect_ols_data_from(data_path)
+    original_result = collect_ols_data_from(data_path)
 
     # create a new file
     with open(data_path + "/new_file.json", "w") as f:
@@ -122,7 +118,7 @@ def mock_collect_ols_data_from(data_path: str) -> list[pathlib.Path]:
     return original_result
 
 
-def test_new_files_stays(tmp_path):
+def test_new_files_stays(tmp_path, mock_data_collector_config):
     """Test gather_ols_user_data.
 
     During the test, a new file is added to directory that is being
@@ -146,7 +142,7 @@ def test_new_files_stays(tmp_path):
             return_value=mock_ingress_response(),
         ),
     ):
-        data_collector.gather_ols_user_data(tmp_path.as_posix())
+        data_collector.gather_ols_user_data(mock_data_collector_config)
 
     # feedback is a dir that is not removed and new_file.json is what
     # we are looking for here
@@ -156,16 +152,16 @@ def test_new_files_stays(tmp_path):
     ]
 
 
-def test_gather_ols_user_data_nothing_to_collect(tmp_path, caplog):
+def test_gather_ols_user_data_nothing_to_collect(caplog, mock_data_collector_config):
     """Test gather_ols_user_data with no data to collect."""
     caplog.set_level(logging.INFO)
 
-    data_collector.gather_ols_user_data(tmp_path.as_posix())
+    data_collector.gather_ols_user_data(mock_data_collector_config)
 
     assert "contains no data, nothing to do..." in caplog.text
 
 
-def test_gather_ols_user_data_full_flow(tmp_path, caplog):
+def test_gather_ols_user_data_full_flow(tmp_path, caplog, mock_data_collector_config):
     """Test gather_ols_user_data.
 
     This is basically script e2e test. We just mocks the ingress.
@@ -181,7 +177,7 @@ def test_gather_ols_user_data_full_flow(tmp_path, caplog):
         "ols.user_data_collection.data_collector.upload_data_to_ingress",
         return_value=mock_ingress_response(),
     ):
-        data_collector.gather_ols_user_data(tmp_path.as_posix())
+        data_collector.gather_ols_user_data(mock_data_collector_config)
 
     # assert correct logs and empty dir where data was
     assert "collected 1 files (splitted to 1 chunks)" in caplog.text
@@ -235,4 +231,6 @@ def test_access_token_from_offline_token():
     """Test the access_token_from_offline_token function."""
     with patch("requests.post", return_value=Response()):
         with pytest.raises(Exception, match="Response is not JSON"):
-            data_collector.access_token_from_offline_token("offline_token")
+            data_collector.access_token_from_offline_token(
+                "offline_token", "ingress_env", 10
+            )

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -876,7 +876,7 @@ def test_valid_config_file():
             }
         )
         assert config.config == expected_config
-        assert config.user_data_collector_config is not None
+        assert config.user_data_collector_config is None
         assert config.ols_config.user_data_collection is not None
         assert config.ols_config.user_data_collection.feedback_disabled is True
         assert config.ols_config.quota_limiter is not None


### PR DESCRIPTION
## Description

Please don't merge this for now, until it's absolutely certain what will be necessary on the config side.

Included:
- script now reads config files only when called as main. 
- decorator turned into simple loop
- configuration for collector will now depend on collection being enabled
- there are no more default user agents
- tests of data collector no longer need global override for imports
- maximum size of user data is now defined in config
- `ingress_env` field of data collector configuration has been replaced with `ingress_url`
- user is now responsible for providing `ingress_url` if the collection is turned on


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
