### PR TITLE
FAISS Vector DB is not loaded after pgvector support change

### DIFF
--- a/ols/src/rag_index/index_loader.py
+++ b/ols/src/rag_index/index_loader.py
@@ -115,9 +115,9 @@ class IndexLoader:
                 table_name=table_name,
                 embed_dim=embed_dim,
             )
-        self._storage_context = StorageContext.from_defaults(
-            vector_store=self._vector_store,
-        )
+            self._storage_context = StorageContext.from_defaults(
+                vector_store=self._vector_store,
+            )
 
     def _load_index(self) -> None:
         """Load vector index."""


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
There was a bug in #412. Due to that bug, FAISS Vector DB is not loaded after #412 change.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
