### PR TITLE
Skip Topic Summarizer when it is not needed

### DIFF
--- a/ols/src/query_helpers/topic_summarizer.py
+++ b/ols/src/query_helpers/topic_summarizer.py
@@ -48,6 +48,12 @@ class TopicSummarizer(QueryHelper):
         Returns:
             str: summarized conversation topic
         """
+        if not prompts.TOPIC_SUMMARY_PROMPT_TEMPLATE:
+            logger.debug(
+                "TOPIC_SUMMARY_PROMPT_TEMPLATE is not set. Topic summarization is skipped."
+            )
+            return ""
+
         settings_string = (
             f"conversation_id: {conversation_id}, "
             f"query: {query}, "

--- a/tests/unit/query_helpers/test_topic_summarizer.py
+++ b/tests/unit/query_helpers/test_topic_summarizer.py
@@ -71,3 +71,17 @@ def test_summarize_topic():
         )
 
         assert response == expected_response
+
+
+@patch("ols.customize.prompts.TOPIC_SUMMARY_PROMPT_TEMPLATE", "")
+def test_skip_summarize_topic():
+    """Test topic summarizer is skipped when TOPIC_SUMMARY_PROMPT_TEMPLATE is not set."""
+    config.reload_from_yaml_file("tests/config/valid_config.yaml")
+
+    summarizer = TopicSummarizer(llm_loader=mock_llm_loader(None))
+    response = summarizer.summarize_topic(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "What are the latest developments in artificial intelligence?",
+    )
+
+    assert response == ""


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We (Ansible Lightspeed Team) found that topic summarizer processing takes a long time when the Granite 3.1 model is used.  For example, just summarizing the one word query `Hello`, it takes 40 secs:
```
2025-03-05 14:46:32,133 [ols.src.query_helpers.topic_summarizer:topic_summarizer.py:83] DEBUG: 8ebe9851-dace-469c-86cd-c9e6f6da7249 summarizing user query: Hello
> Entering new LLMChain chain...
Prompt after formatting:
Instructions:
- You are a topic summarizer
- Your job is to extract precise topic summary from user input
For Input Analysis:
- Scan entire user message
- Identify core subject matter
- Distill essence into concise descriptor
- Prioritize key concepts
- Eliminate extraneous details
For Output Constraints:
- Maximum 5 words
- Uppercase first letter of significant words
- Avoid articles prepositions
- Exclude punctuation
- Neutral objective language
Processing Steps
1. Analyze semantic structure
2. Identify primary topic
3. Remove contextual noise
4. Condense to essential meaning
5. Generate topic label
Example Input:
How to implement horizontal pod autoscaling in Kubernetes clusters
Example Output:
Kubernetes Horizontal Pod Autoscaling
Example Input:
Comparing OpenShift deployment strategies for microservices architecture
Example Output:
OpenShift Microservices Deployment Strategies
Example Input:
Troubleshooting persistent volume claims in Kubernetes environments
Example Output:
Kubernetes Persistent Volume Troubleshooting
Input:
Hello
Output:
> Finished chain.
2025-03-05 14:47:12,244 [ols.src.query_helpers.topic_summarizer:topic_summarizer.py:95] DEBUG: 8ebe9851-dace-469c-86cd-c9e6f6da7249 summarizer response: HELLO
```
Since we do not use summarized results in our chatbot right now, we would like to disable topic summarization if `TOPIC_SUMMARY_PROMPT_TEMPLATE` is defined as an empty string in `prompts`.

Note: Granite v3 (not v3.1) model does not have this problem and topic summarization for the query `Hello` completes in less than 1 sec.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

When `TOPIC_SUMMARY_PROMPT_TEMPLATE` is set to an empty string and log level is set to debug, you'll see
```
TOPIC_SUMMARY_PROMPT_TEMPLATE is not set. Topic summarization is skipped.
```
in the log output after sending the first query.