### PR TITLE
include last_message_timestamp in list conversations API

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1206,7 +1206,14 @@
                     "conversations": {
                         "items": {
                             "additionalProperties": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
                             },
                             "type": "object"
                         },
@@ -1219,20 +1226,23 @@
                     "conversations"
                 ],
                 "title": "ListConversationsResponse",
-                "description": "Model representing a response to a request to retrieve a conversation history.\n\nAttributes:\n    conversations: List of conversation IDs.",
+                "description": "Model representing a response to a request to retrieve a conversation history.\n\nAttributes:\n    conversations: List of conversation IDs, summary and last message timestamp.",
                 "examples": [
                     {
                         "conversations": [
                             {
                                 "conversation_id": "15a78660-a18e-447b-9fea-9deb27b63b5f",
+                                "last_message_timestamp": 1741268849.345408,
                                 "topic_summary": "topic1"
                             },
                             {
                                 "conversation_id": "c0a3bc27-77cc-46da-822f-93a9c0e0de4b",
+                                "last_message_timestamp": 1741268599.387008,
                                 "topic_summary": "topic2"
                             },
                             {
                                 "conversation_id": "51984bb1-f3a3-4ab2-9df6-cf92c30bbb7f",
+                                "last_message_timestamp": 1741289849.349808,
                                 "topic_summary": "topic3"
                             }
                         ]

--- a/ols/app/endpoints/conversations.py
+++ b/ols/app/endpoints/conversations.py
@@ -220,5 +220,14 @@ def list_conversations(
 
     if history_length is not None:
         conversations = conversations[:history_length]
+    
+    new_conversations = []
+    for conv in conversations:
+        conversation_id = conv["conversation_id"]
+        chat_history = CacheEntry.cache_entries_to_history(
+            retrieve_previous_input(user_id, conversation_id, skip_user_id_check)
+        )
+        conv["last_message_timestamp"] = chat_history[-1].response_metadata["created_at"]
+        new_conversations.append(conv)
 
-    return ListConversationsResponse(conversations=conversations)
+    return ListConversationsResponse(conversations=new_conversations)

--- a/ols/app/endpoints/conversations.py
+++ b/ols/app/endpoints/conversations.py
@@ -220,14 +220,16 @@ def list_conversations(
 
     if history_length is not None:
         conversations = conversations[:history_length]
-    
+
     new_conversations = []
     for conv in conversations:
         conversation_id = conv["conversation_id"]
         chat_history = CacheEntry.cache_entries_to_history(
             retrieve_previous_input(user_id, conversation_id, skip_user_id_check)
         )
-        conv["last_message_timestamp"] = chat_history[-1].response_metadata["created_at"]
+        conv["last_message_timestamp"] = chat_history[-1].response_metadata[
+            "created_at"
+        ]
         new_conversations.append(conv)
 
     return ListConversationsResponse(conversations=new_conversations)

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -240,12 +240,14 @@ class ChatHistoryResponse(BaseModel):
         }
     }
 
+
 class ListConversationsResponse(BaseModel):
     """Model representing a response to a request to retrieve a conversation history.
 
     Attributes:
         conversations: List of conversation IDs, summary and last message timestamp.
     """
+
     conversations: list[dict[str, Union[str, float]]]
 
     # provides examples for /docs endpoint

--- a/ols/app/models/models.py
+++ b/ols/app/models/models.py
@@ -240,15 +240,13 @@ class ChatHistoryResponse(BaseModel):
         }
     }
 
-
 class ListConversationsResponse(BaseModel):
     """Model representing a response to a request to retrieve a conversation history.
 
     Attributes:
-        conversations: List of conversation IDs.
+        conversations: List of conversation IDs, summary and last message timestamp.
     """
-
-    conversations: list[dict[str, str]]
+    conversations: list[dict[str, Union[str, float]]]
 
     # provides examples for /docs endpoint
     model_config = {
@@ -259,14 +257,17 @@ class ListConversationsResponse(BaseModel):
                         {
                             "conversation_id": "15a78660-a18e-447b-9fea-9deb27b63b5f",
                             "topic_summary": "topic1",
+                            "last_message_timestamp": 1741268849.345408,
                         },
                         {
                             "conversation_id": "c0a3bc27-77cc-46da-822f-93a9c0e0de4b",
                             "topic_summary": "topic2",
+                            "last_message_timestamp": 1741268599.387008,
                         },
                         {
                             "conversation_id": "51984bb1-f3a3-4ab2-9df6-cf92c30bbb7f",
                             "topic_summary": "topic3",
+                            "last_message_timestamp": 1741289849.349808,
                         },
                     ]
                 }

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -191,10 +191,14 @@ def test_list_conversations_with_history(_setup, endpoint):
         found_conv_ids = {conv["conversation_id"] for conv in conversations}
         assert conv_id_1 in found_conv_ids
         assert conv_id_2 in found_conv_ids
+
         for conv in conversations:
             assert (
                 "topic_summary" in conv
             ), f"Conversation {conv['conversation_id']} is missing topic_summary"
+            assert (
+                "last_message_timestamp" in conv
+            ), f"Conversation {conv['conversation_id']} is missing last_message_timestamp"
 
 
 @pytest.mark.parametrize("endpoint", ("/conversations",))


### PR DESCRIPTION
## Description
The current road-core list conversations API only returns `conversation_id` and `topic_summary` for each conversation.

this PR adds one more info, lastMessageTimestamp, to be returned. 
so that UI can group and list it.

for example:
![Screenshot 2025-03-06 at 2 22 49 PM](https://github.com/user-attachments/assets/cedeeaf0-71e9-4ed6-8416-edc2ab88ef7b)





<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/RHDHPAI-650

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
