### PR TITLE
Make JSON events stream as default `application/json` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ curl -X 'POST' 'http://127.0.0.1:8080/v1/query' -H 'accept: application/json' -H
 
 > You can use the `/v1/streaming_query` (with the same parameters) to get the streaming response (SSE/HTTP chunking). By default, it streams text, but you can also yield events as JSONs via additional `"media_type": "application/json"` parameter in the payload data.
 
+> The format of individual events is `"data: {JSON}\n\n"`.
+
 > In the devel environment where authentication module is set to `noop` it is possible to specify an optional query parameter `user_id` with the user identification. This parameter can be set to any value, but currently it is preferred to use UUID.
 
 

--- a/docs/config.puml
+++ b/docs/config.puml
@@ -89,7 +89,6 @@ class "OLSConfig" as ols.app.models.config.OLSConfig {
   conversation_cache : Optional[ConversationCacheConfig]
   default_model : Optional[str]
   default_provider : Optional[str]
-  enable_event_stream_format : bool
   expire_llm_is_ready_persistent_state : Optional[int]
   extra_ca : list[FilePath]
   logging_config : Optional[LoggingConfig]

--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -73,7 +73,6 @@ ols_config:
   default_provider: my_bam
   default_model: ibm/granite-3-8b-instruct
   expire_llm_is_ready_persistent_state: -1
-  enable_event_stream_format: true
   # query_filters:
   #   - name: foo_filter
   #     pattern: '\b(?:foo)\b'

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1014,7 +1014,6 @@ class OLSConfig(BaseModel):
     extra_ca: list[FilePath] = []
     certificate_directory: Optional[str] = None
 
-    enable_event_stream_format: bool = False
     quota_handlers: Optional[QuotaHandlersConfig] = None
 
     def __init__(
@@ -1067,7 +1066,6 @@ class OLSConfig(BaseModel):
         self.tls_security_profile = TLSSecurityProfile(
             data.get("tlsSecurityProfile", None)
         )
-        self.enable_event_stream_format = data.get("enable_event_stream_format", False)
         self.quota_handlers = QuotaHandlersConfig(data.get("quota_handlers", None))
 
     def __eq__(self, other: object) -> bool:
@@ -1090,7 +1088,6 @@ class OLSConfig(BaseModel):
                 and self.authentication_config == other.authentication_config
                 and self.expire_llm_is_ready_persistent_state
                 == other.expire_llm_is_ready_persistent_state
-                and self.enable_event_stream_format == other.enable_event_stream_format
                 and self.quota_handlers == other.quota_handlers
             )
         return False


### PR DESCRIPTION
## Description

Make JSON events stream as default `application/json` format

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
