### PR TITLE
Remove mock connect decorator from quota unit tests

### DIFF
--- a/tests/unit/quota/test_quota_limiter_factory.py
+++ b/tests/unit/quota/test_quota_limiter_factory.py
@@ -36,8 +36,7 @@ def test_quota_limiters_empty_limiters():
     assert limiters == []
 
 
-@patch("psycopg2.connect")
-def test_quota_limiters_user_quota_limiter(postgres_mock):
+def test_quota_limiters_user_quota_limiter():
     """Test the quota limiters creating when one limiter is specified."""
     config = QuotaHandlersConfig()
     config.storage = PostgresConfig()
@@ -52,13 +51,14 @@ def test_quota_limiters_user_quota_limiter(postgres_mock):
             }
         ]
     )
-    limiters = QuotaLimiterFactory.quota_limiters(config)
-    assert len(limiters) == 1
-    assert isinstance(limiters[0], UserQuotaLimiter)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect"):
+        limiters = QuotaLimiterFactory.quota_limiters(config)
+        assert len(limiters) == 1
+        assert isinstance(limiters[0], UserQuotaLimiter)
 
 
-@patch("psycopg2.connect")
-def test_quota_limiters_cluster_quota_limiter(postgres_mock):
+def test_quota_limiters_cluster_quota_limiter():
     """Test the quota limiters creating when one limiter is specified."""
     config = QuotaHandlersConfig()
     config.storage = PostgresConfig()
@@ -73,13 +73,14 @@ def test_quota_limiters_cluster_quota_limiter(postgres_mock):
             }
         ]
     )
-    limiters = QuotaLimiterFactory.quota_limiters(config)
-    assert len(limiters) == 1
-    assert isinstance(limiters[0], ClusterQuotaLimiter)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect"):
+        limiters = QuotaLimiterFactory.quota_limiters(config)
+        assert len(limiters) == 1
+        assert isinstance(limiters[0], ClusterQuotaLimiter)
 
 
-@patch("psycopg2.connect")
-def test_quota_limiters_two_limiters(postgres_mock):
+def test_quota_limiters_two_limiters():
     """Test the quota limiters creating when two limiters are specified."""
     config = QuotaHandlersConfig()
     config.storage = PostgresConfig()
@@ -101,14 +102,15 @@ def test_quota_limiters_two_limiters(postgres_mock):
             },
         ]
     )
-    limiters = QuotaLimiterFactory.quota_limiters(config)
-    assert len(limiters) == 2
-    assert isinstance(limiters[0], UserQuotaLimiter)
-    assert isinstance(limiters[1], ClusterQuotaLimiter)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect"):
+        limiters = QuotaLimiterFactory.quota_limiters(config)
+        assert len(limiters) == 2
+        assert isinstance(limiters[0], UserQuotaLimiter)
+        assert isinstance(limiters[1], ClusterQuotaLimiter)
 
 
-@patch("psycopg2.connect")
-def test_quota_limiters_unknown_limiter(postgres_mock):
+def test_quota_limiters_unknown_limiter():
     """Test the quota limiters creating when the limiter type is unknown."""
     config = QuotaHandlersConfig()
     config.storage = PostgresConfig()
@@ -123,5 +125,7 @@ def test_quota_limiters_unknown_limiter(postgres_mock):
             }
         ]
     )
-    with pytest.raises(ValueError, match="Invalid limiter type: UNKNOWN."):
-        QuotaLimiterFactory.quota_limiters(config)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect"):
+        with pytest.raises(ValueError, match="Invalid limiter type: UNKNOWN."):
+            QuotaLimiterFactory.quota_limiters(config)

--- a/tests/unit/quota/test_user_quota_limiter.py
+++ b/tests/unit/quota/test_user_quota_limiter.py
@@ -9,26 +9,27 @@ from ols.app.models.config import PostgresConfig
 from ols.src.quota.user_quota_limiter import UserQuotaLimiter
 
 
-@patch("psycopg2.connect")
-def test_init_storage_failure_detection(mock_connect):
+def test_init_storage_failure_detection():
     """Test the exception handling for storage initialize operation."""
     exception_message = "Exception during PostgreSQL storage."
-    mock_connect.return_value.cursor.return_value.execute.side_effect = Exception(
-        exception_message
-    )
 
-    # try to connect to mocked Postgres
-    config = PostgresConfig()
-    with pytest.raises(Exception, match=exception_message):
-        UserQuotaLimiter(config, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.execute.side_effect = Exception(
+            exception_message
+        )
 
-    # connection must be closed in case of exception
-    mock_connect.return_value.close.assert_called_once_with()
+        # try to connect to mocked Postgres
+        config = PostgresConfig()
+        with pytest.raises(Exception, match=exception_message):
+            UserQuotaLimiter(config, 0)
+
+        # connection must be closed in case of exception
+        mock_connect.return_value.close.assert_called_once_with()
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_init_quota(mock_datetime, mock_connect):
+def test_init_quota(mock_datetime):
     """Test the init quota operation."""
     quota_limit = 100
     user_id = "1234"
@@ -37,20 +38,25 @@ def test_init_quota(mock_datetime, mock_connect):
     # mock the query result - with empty storage
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # init quota for given user
-    q._init_quota(user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # init quota for given user
+        q._init_quota(user_id)
 
     # new record should be inserted into storage
     mock_cursor.execute.assert_called_once_with(
@@ -59,8 +65,7 @@ def test_init_quota(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
-def test_available_quota_with_data(mock_connect):
+def test_available_quota_with_data():
     """Test the get available quota operation."""
     quota_limit = 100
     available_quota = 50
@@ -70,14 +75,19 @@ def test_available_quota_with_data(mock_connect):
     # mock the query result - available data in the table
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (available_quota,)
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # try to retrieve available quota for given user
-    available = q.available_quota(user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to retrieve available quota for given user
+        available = q.available_quota(user_id)
 
     # quota for given user should be read from storage
     mock_cursor.execute.assert_called_once_with(
@@ -86,9 +96,8 @@ def test_available_quota_with_data(mock_connect):
     assert available == available_quota
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_available_quota_no_data(mock_datetime, mock_connect):
+def test_available_quota_no_data(mock_datetime):
     """Test the get available quota operation."""
     quota_limit = 100
     user_id = "1234"
@@ -97,20 +106,25 @@ def test_available_quota_no_data(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to retrieve available quota for given user
-    available = q.available_quota(user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to retrieve available quota for given user
+        available = q.available_quota(user_id)
 
     # quota for given user should be read from storage
     # and the initialization of new record should be made
@@ -125,9 +139,8 @@ def test_available_quota_no_data(mock_datetime, mock_connect):
     assert available == quota_limit
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_revoke_quota(mock_datetime, mock_connect):
+def test_revoke_quota(mock_datetime):
     """Test the operation to revoke quota."""
     quota_limit = 100
     user_id = "1234"
@@ -136,20 +149,25 @@ def test_revoke_quota(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to revoke quota
-    q.revoke_quota(user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to revoke quota
+        q.revoke_quota(user_id)
 
     # quota for given user should be written into the storage
     mock_cursor.execute.assert_called_once_with(
@@ -158,9 +176,8 @@ def test_revoke_quota(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_consume_tokens_not_enough(mock_datetime, mock_connect):
+def test_consume_tokens_not_enough(mock_datetime):
     """Test the operation to consume tokens."""
     to_be_consumed = 100
     available_tokens = 50
@@ -171,20 +188,25 @@ def test_consume_tokens_not_enough(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (available_tokens,)
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to consume tokens
-    q.consume_tokens(to_be_consumed, 0, user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to consume tokens
+        q.consume_tokens(to_be_consumed, 0, user_id)
 
     # quota for given user should be updated in storage
     mock_cursor.execute.assert_called_once_with(
@@ -193,9 +215,8 @@ def test_consume_tokens_not_enough(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_consume_input_tokens_enough_tokens(mock_datetime, mock_connect):
+def test_consume_input_tokens_enough_tokens(mock_datetime):
     """Test the operation to consume tokens."""
     to_be_consumed = 50
     available_tokens = 100
@@ -206,20 +227,25 @@ def test_consume_input_tokens_enough_tokens(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (available_tokens,)
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to consume tokens
-    q.consume_tokens(to_be_consumed, 0, user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to consume tokens
+        q.consume_tokens(to_be_consumed, 0, user_id)
 
     mock_cursor.execute.assert_called_once_with(
         UserQuotaLimiter.UPDATE_AVAILABLE_QUOTA,
@@ -227,9 +253,8 @@ def test_consume_input_tokens_enough_tokens(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_consume_output_tokens_enough_tokens(mock_datetime, mock_connect):
+def test_consume_output_tokens_enough_tokens(mock_datetime):
     """Test the operation to consume tokens."""
     to_be_consumed = 50
     available_tokens = 100
@@ -240,20 +265,25 @@ def test_consume_output_tokens_enough_tokens(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (available_tokens,)
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to consume tokens
-    q.consume_tokens(0, to_be_consumed, user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to consume tokens
+        q.consume_tokens(0, to_be_consumed, user_id)
 
     mock_cursor.execute.assert_called_once_with(
         UserQuotaLimiter.UPDATE_AVAILABLE_QUOTA,
@@ -261,9 +291,8 @@ def test_consume_output_tokens_enough_tokens(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_consume_input_and_output_tokens_enough_tokens(mock_datetime, mock_connect):
+def test_consume_input_and_output_tokens_enough_tokens(mock_datetime):
     """Test the operation to consume tokens."""
     input_tokens = 30
     output_tokens = 20
@@ -276,20 +305,25 @@ def test_consume_input_and_output_tokens_enough_tokens(mock_datetime, mock_conne
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (available_tokens,)
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to consume tokens
-    q.consume_tokens(input_tokens, output_tokens, user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        # try to consume tokens
+        q.consume_tokens(input_tokens, output_tokens, user_id)
 
     mock_cursor.execute.assert_called_once_with(
         UserQuotaLimiter.UPDATE_AVAILABLE_QUOTA,
@@ -297,9 +331,8 @@ def test_consume_input_and_output_tokens_enough_tokens(mock_datetime, mock_conne
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_consume_tokens_on_no_record(mock_datetime, mock_connect):
+def test_consume_tokens_on_no_record(mock_datetime):
     """Test the operation to consume tokens."""
     to_be_consumed = 100
     quota_limit = 100
@@ -309,19 +342,24 @@ def test_consume_tokens_on_no_record(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    q.consume_tokens(to_be_consumed, 0, user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit)
+
+        q.consume_tokens(to_be_consumed, 0, user_id)
 
     # quota for given user should be read from storage
     mock_cursor.execute.assert_called_once_with(
@@ -330,9 +368,8 @@ def test_consume_tokens_on_no_record(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_increase_quota(mock_datetime, mock_connect):
+def test_increase_quota(mock_datetime):
     """Test the operation to increase quota."""
     quota_limit = 100
     additional_quota = 10
@@ -342,20 +379,25 @@ def test_increase_quota(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit, additional_quota)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    # try to increase quota
-    q.increase_quota(user_id)
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit, additional_quota)
+
+        # try to increase quota
+        q.increase_quota(user_id)
 
     # quota for given user should be written into the storage
     mock_cursor.execute.assert_called_once_with(
@@ -364,9 +406,8 @@ def test_increase_quota(mock_datetime, mock_connect):
     )
 
 
-@patch("psycopg2.connect")
 @patch("ols.src.quota.revokable_quota_limiter.datetime")
-def test_ensure_available_quota(mock_datetime, mock_connect):
+def test_ensure_available_quota(mock_datetime):
     """Test the operation to increase quota."""
     quota_limit = 0
     additional_quota = 0
@@ -375,20 +416,25 @@ def test_ensure_available_quota(mock_datetime, mock_connect):
     # mock the query result - no data
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = None
-    mock_connect.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
-    # mock for real timestamp
-    timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
+    # do not use connection to real PostgreSQL instance
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
 
-    # mock function to retrieve timestamp
-    mock_datetime.now = lambda: timestamp
+        # mock for real timestamp
+        timestamp = datetime.datetime(2000, 1, 1, 12, 0, 0)
 
-    # initialize Postgres storage
-    config = PostgresConfig()
-    q = UserQuotaLimiter(config, quota_limit, additional_quota)
+        # mock function to retrieve timestamp
+        mock_datetime.now = lambda: timestamp
 
-    exception_message = "User 1234 has no available tokens"
+        # initialize Postgres storage
+        config = PostgresConfig()
+        q = UserQuotaLimiter(config, quota_limit, additional_quota)
 
-    # check available quota
-    with pytest.raises(Exception, match=exception_message):
-        q.ensure_available_quota(user_id)
+        exception_message = "User 1234 has no available tokens"
+
+        # check available quota
+        with pytest.raises(Exception, match=exception_message):
+            q.ensure_available_quota(user_id)


### PR DESCRIPTION
## Description

Remove mock connect decorator from quota unit tests
Partially solves bug #427

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
