### PR TITLE
Fixes #389: Setting permissions in all GitHub actions

### DIFF
--- a/.github/workflows/outdated_dependencies.yaml
+++ b/.github/workflows/outdated_dependencies.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   list_outdated_dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/pydocstyle.yaml
+++ b/.github/workflows/pydocstyle.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   pydocstyle:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   pylint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Description

Fixes #389: Setting permissions in all GitHub actions

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #389
