### PR TITLE
OLS-1521: Switch to new granite-3-8b-instruct model from IBM

### DIFF
--- a/tests/e2e/test_streaming_query_endpoint.py
+++ b/tests/e2e/test_streaming_query_endpoint.py
@@ -500,7 +500,7 @@ def test_query_with_model_but_not_provider() -> None:
             json={
                 "conversation_id": "",
                 "query": "what is kubernetes?",
-                "model": "ibm/granite-13b-chat-v2",
+                "model": "ibm/granite-3-8b-instruct",
             },
         )
         assert response.status_code == requests.codes.unprocessable_entity


### PR DESCRIPTION
## Description

OLS-1521: Switch to new granite-3-8b-instruct model from IBM
(this is the last remaining piece)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #OLS-1521
