### PR TITLE
OLS-1519: no @patch decorator in benchmarks

### DIFF
--- a/tests/benchmarks/test_docs_summarizer.py
+++ b/tests/benchmarks/test_docs_summarizer.py
@@ -47,41 +47,51 @@ def rag_index():
     return MockLlamaIndex()
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_empty_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine."""
     question = "What's the ultimate question with answer 42?"
     history = []  # empty history
 
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_no_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine, no history is provided."""
     question = "What's the ultimate question with answer 42?"
 
-    # no history is passed into summarize() method
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # no history is passed into summarize() method
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_history_provided(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine, history is provided."""
     question = "What's the ultimate question with answer 42?"
     history = [HumanMessage("What is Kubernetes?")]
 
-    # first call with history provided
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # first call with history provided
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_history_truncation(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?"
@@ -89,8 +99,14 @@ def test_summarize_history_truncation(benchmark, rag_index, summarizer):
     # too long history
     history = [HumanMessage("What is Kubernetes?")] * 10
 
-    # run the benchmark
-    benchmark(summarizer.create_response, question, rag_index, history)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # run the benchmark
+        benchmark(summarizer.create_response, question, rag_index, history)
 
 
 def try_to_run_summarizer(summarizer, question, rag_index, history):
@@ -99,8 +115,6 @@ def try_to_run_summarizer(summarizer, question, rag_index, history):
         summarizer.summarize(conversation_id, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_too_long_question(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?" * 10000
@@ -108,12 +122,16 @@ def test_summarize_too_long_question(benchmark, rag_index, summarizer):
     # short history
     history = ["What is Kubernetes?"]
 
-    # run the benchmark
-    benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # run the benchmark
+        benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_too_long_question_long_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer to check if truncation is done."""
     question = "What's the ultimate question with answer 42?" * 10000
@@ -121,14 +139,22 @@ def test_summarize_too_long_question_long_history(benchmark, rag_index, summariz
     # too long history
     history = ["What is Kubernetes?"] * 10000
 
-    # run the benchmark
-    benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        # run the benchmark
+        benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
 
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_no_reference_content(benchmark, summarizer_no_reference_content):
     """Benchmark for DocsSummarizer using mocked index and query engine."""
     question = "What's the ultimate question with answer 42?"
 
-    # run the benchmark
-    benchmark(summarizer_no_reference_content.create_response, question)
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+    ):
+        # run the benchmark
+        benchmark(summarizer_no_reference_content.create_response, question)

--- a/tests/benchmarks/test_question_validator.py
+++ b/tests/benchmarks/test_question_validator.py
@@ -13,35 +13,37 @@ from tests.mock_classes.mock_llm_chain import mock_llm_chain  # noqa: E402
 from tests.mock_classes.mock_llm_loader import mock_llm_loader  # noqa: E402
 
 
-@patch("ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None))
 def perform_question_validation_benchmark(benchmark, question):
     """Prepare all mocks and the call the QuestionValidator.validate_question method."""
     # it is needed to initialize configuration in order to be able
     # to construct QuestionValidator instance
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
-    # when the LLM will be initialized the check for provided parameters will
-    # be performed
-    llm_loader = mock_llm_loader(
-        None,
-        expected_params=(
-            "p1",
-            "m1",
-            {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
-            False,
-        ),
-    )
+    with patch(
+        "ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None)
+    ):
+        # when the LLM will be initialized the check for provided parameters will
+        # be performed
+        llm_loader = mock_llm_loader(
+            None,
+            expected_params=(
+                "p1",
+                "m1",
+                {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
+                False,
+            ),
+        )
 
-    # check that LLM loader was called with expected parameters
-    question_validator = QuestionValidator(llm_loader=llm_loader)
+        # check that LLM loader was called with expected parameters
+        question_validator = QuestionValidator(llm_loader=llm_loader)
 
-    # just run the validation for the provided question, we just need to check
-    # parameters passed to LLM that is performed in mock object
-    benchmark(
-        question_validator.validate_question,
-        "123e4567-e89b-12d3-a456-426614174000",
-        question,
-    )
+        # just run the validation for the provided question, we just need to check
+        # parameters passed to LLM that is performed in mock object
+        benchmark(
+            question_validator.validate_question,
+            "123e4567-e89b-12d3-a456-426614174000",
+            question,
+        )
 
 
 def test_validate_question_short_question(benchmark):


### PR DESCRIPTION
## Description

OLS-1519: no `@patch` decorator in benchmarks

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests

## Related Tickets & Documents

- Related Issue #OLS-1519
