### PR TITLE
Removed all remaining @patch decorators from unit tests

### DIFF
--- a/tests/unit/llms/providers/test_azure_openai.py
+++ b/tests/unit/llms/providers/test_azure_openai.py
@@ -438,39 +438,42 @@ def mocked_token_cache():
     return MockedTokenCache
 
 
-@patch(
-    "ols.src.llms.providers.azure_openai.ClientSecretCredential", new=MockedCredential
-)
 def test_retrieve_access_token(provider_config_access_token_related_parameters):
     """Test that access token is being retrieved."""
-    azure_openai = AzureOpenAI(
-        model="uber-model",
-        params={},
-        provider_config=provider_config_access_token_related_parameters,
-    )
-    assert "api_key" not in azure_openai.default_params
-    assert (
-        azure_openai.default_params["azure_ad_token"]
-        == "this-is-access-token"  # noqa: S105
-    )
+    with patch(
+        "ols.src.llms.providers.azure_openai.ClientSecretCredential",
+        new=MockedCredential,
+    ):
+        azure_openai = AzureOpenAI(
+            model="uber-model",
+            params={},
+            provider_config=provider_config_access_token_related_parameters,
+        )
+        assert "api_key" not in azure_openai.default_params
+        assert (
+            azure_openai.default_params["azure_ad_token"]
+            == "this-is-access-token"  # noqa: S105
+        )
 
 
-@patch(
-    "ols.src.llms.providers.azure_openai.ClientSecretCredential",
-    new=MockedCredentialThrowingException,
-)
-@patch("ols.src.llms.providers.azure_openai.TokenCache.expires_on", new=0)
 def test_retrieve_access_token_on_error(
     provider_config_access_token_related_parameters,
 ):
     """Test how error is handled during accessing token."""
-    azure_openai = AzureOpenAI(
-        model="uber-model",
-        params={},
-        provider_config=provider_config_access_token_related_parameters,
-    )
-    assert "api_key" not in azure_openai.default_params
-    assert azure_openai.default_params["azure_ad_token"] is None
+    with (
+        patch(
+            "ols.src.llms.providers.azure_openai.ClientSecretCredential",
+            new=MockedCredentialThrowingException,
+        ),
+        patch("ols.src.llms.providers.azure_openai.TokenCache.expires_on", new=0),
+    ):
+        azure_openai = AzureOpenAI(
+            model="uber-model",
+            params={},
+            provider_config=provider_config_access_token_related_parameters,
+        )
+        assert "api_key" not in azure_openai.default_params
+        assert azure_openai.default_params["azure_ad_token"] is None
 
 
 def test_token_is_expired():

--- a/tests/unit/llms/providers/test_watsonx.py
+++ b/tests/unit/llms/providers/test_watsonx.py
@@ -99,16 +99,17 @@ def provider_config_with_specific_params():
     )
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_basic_interface(provider_config):
     """Test basic interface."""
-    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params={}, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling(provider_config):
     """Test that not allowed parameters are removed before model init."""
     # first two parameters should be removed before model init
@@ -121,69 +122,69 @@ def test_params_handling(provider_config):
         "temperature": 0.3,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # taken from configuration
-    assert watsonx.url == "https://us-south.ml.cloud.ibm.com"
-    assert watsonx.credentials == "secret_key"
-    assert watsonx.project_id == "01234567-89ab-cdef-0123-456789abcdef"
+        # taken from configuration
+        assert watsonx.url == "https://us-south.ml.cloud.ibm.com"
+        assert watsonx.credentials == "secret_key"
+        assert watsonx.project_id == "01234567-89ab-cdef-0123-456789abcdef"
 
-    # known parameters should be there
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+        # known parameters should be there
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
 
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 10
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 10
 
-    # unknown parameters should be filtered out
-    assert "unknown_parameter" not in watsonx.params
-    assert "verbose" not in watsonx.params
+        # unknown parameters should be filtered out
+        assert "unknown_parameter" not in watsonx.params
+        assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_credentials_key_in_directory_handling(provider_config_credentials_directory):
     """Test that credentials in directory is handled as expected."""
     params = {}
 
-    watsonx = Watsonx(
-        model="uber-model",
-        params=params,
-        provider_config=provider_config_credentials_directory,
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params=params,
+            provider_config=provider_config_credentials_directory,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
 
-    # taken from configuration
-    assert watsonx.credentials == "secret_key"
+        # taken from configuration
+        assert watsonx.credentials == "secret_key"
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_specific_params(provider_config_with_specific_params):
     """Test that provider-specific parameters take precedence."""
-    watsonx = Watsonx(
-        model="uber-model",
-        params={},
-        provider_config=provider_config_with_specific_params,
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params={},
+            provider_config=provider_config_with_specific_params,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # parameters taken from provier-specific configuration
-    # which takes precedence over regular configuration
-    assert watsonx.url == "http://bam.com/"
-    assert watsonx.credentials == "secret_key_2"
-    assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
+        # parameters taken from provier-specific configuration
+        # which takes precedence over regular configuration
+        assert watsonx.url == "http://bam.com/"
+        assert watsonx.credentials == "secret_key_2"
+        assert watsonx.project_id == "ffffffff-89ab-cdef-0123-456789abcdef"
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_handling_none_values(provider_config):
     """Test handling parameters with None values."""
     # first three parameters should be removed before model init
@@ -196,54 +197,56 @@ def test_params_handling_none_values(provider_config):
         "max_new_tokens": None,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # known parameters should be there
-    assert GenParams.MIN_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MIN_NEW_TOKENS] is None
+        # known parameters should be there
+        assert GenParams.MIN_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MIN_NEW_TOKENS] is None
 
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] is None
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] is None
 
-    assert GenParams.TEMPERATURE in watsonx.params
-    assert watsonx.params[GenParams.TEMPERATURE] is None
+        assert GenParams.TEMPERATURE in watsonx.params
+        assert watsonx.params[GenParams.TEMPERATURE] is None
 
-    # unknown parameters should be filtered out
-    assert "unknown_parameter" not in watsonx.params
-    assert "verbose" not in watsonx.params
+        # unknown parameters should be filtered out
+        assert "unknown_parameter" not in watsonx.params
+        assert "verbose" not in watsonx.params
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_params_replace_default_values_with_none(provider_config):
     """Test if default values are replaced by None values."""
-    # provider initialization with empty set of params
-    watsonx = Watsonx(model="uber-model", params={}, provider_config=provider_config)
-    watsonx.load()
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        # provider initialization with empty set of params
+        watsonx = Watsonx(
+            model="uber-model", params={}, provider_config=provider_config
+        )
+        watsonx.load()
 
-    # check default value
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
+        # check default value
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] == "sample"
 
-    # provider initialization where default parameter is overriden
-    params = {"decoding_method": None}
+        # provider initialization where default parameter is overriden
+        params = {"decoding_method": None}
 
-    watsonx = Watsonx(
-        model="uber-model", params=params, provider_config=provider_config
-    )
-    watsonx.load()
+        watsonx = Watsonx(
+            model="uber-model", params=params, provider_config=provider_config
+        )
+        watsonx.load()
 
-    # check default value overrided by None
-    assert GenParams.DECODING_METHOD in watsonx.params
-    assert watsonx.params[GenParams.DECODING_METHOD] is None
+        # check default value overrided by None
+        assert GenParams.DECODING_METHOD in watsonx.params
+        assert watsonx.params[GenParams.DECODING_METHOD] is None
 
 
-@patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx())
 def test_generic_parameter_mappings(provider_config):
     """Test generic parameter mapping to provider parameter list."""
     # some non-default values for generic LLM parameters
@@ -255,25 +258,28 @@ def test_generic_parameter_mappings(provider_config):
         GenericLLMParameters.TEMPERATURE: 42.0,
     }
 
-    watsonx = Watsonx(
-        model="uber-model", params=generic_llm_params, provider_config=provider_config
-    )
-    llm = watsonx.load()
-    assert isinstance(llm, ChatWatsonx)
-    assert watsonx.default_params
-    assert watsonx.params
+    with patch("ols.src.llms.providers.watsonx.ChatWatsonx", new=ChatWatsonx()):
+        watsonx = Watsonx(
+            model="uber-model",
+            params=generic_llm_params,
+            provider_config=provider_config,
+        )
+        llm = watsonx.load()
+        assert isinstance(llm, ChatWatsonx)
+        assert watsonx.default_params
+        assert watsonx.params
 
-    # generic parameters should be remapped to Watsonx-specific parameters
-    assert GenParams.MIN_NEW_TOKENS in watsonx.params
-    assert GenParams.MAX_NEW_TOKENS in watsonx.params
-    assert GenParams.TOP_K in watsonx.params
-    assert GenParams.TOP_P in watsonx.params
-    assert GenParams.TEMPERATURE in watsonx.params
-    assert watsonx.params[GenParams.MIN_NEW_TOKENS] == 100
-    assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 200
-    assert watsonx.params[GenParams.TOP_K] == 10
-    assert watsonx.params[GenParams.TOP_P] == 1.5
-    assert watsonx.params[GenParams.TEMPERATURE] == 42.0
+        # generic parameters should be remapped to Watsonx-specific parameters
+        assert GenParams.MIN_NEW_TOKENS in watsonx.params
+        assert GenParams.MAX_NEW_TOKENS in watsonx.params
+        assert GenParams.TOP_K in watsonx.params
+        assert GenParams.TOP_P in watsonx.params
+        assert GenParams.TEMPERATURE in watsonx.params
+        assert watsonx.params[GenParams.MIN_NEW_TOKENS] == 100
+        assert watsonx.params[GenParams.MAX_NEW_TOKENS] == 200
+        assert watsonx.params[GenParams.TOP_K] == 10
+        assert watsonx.params[GenParams.TOP_P] == 1.5
+        assert watsonx.params[GenParams.TEMPERATURE] == 42.0
 
 
 def test_missing_credentials_check(provider_config_without_credentials):

--- a/tests/unit/llms/test_llm_loader.py
+++ b/tests/unit/llms/test_llm_loader.py
@@ -58,7 +58,6 @@ def test_model_config_missing_error():
         load_llm(provider="bam", model="bla")
 
 
-@patch("ols.src.llms.llm_loader.LLMProvidersRegistry", new=MagicMock())
 def test_unsupported_provider_error():
     """Test raise when provider is not in the registry (not implemented)."""
     providers = LLMProviders(
@@ -66,27 +65,30 @@ def test_unsupported_provider_error():
     )
     config.config.llm_providers = providers
 
-    with pytest.raises(UnsupportedProviderError):
+    with (
+        patch("ols.src.llms.llm_loader.LLMProvidersRegistry", new=MagicMock()),
+        pytest.raises(UnsupportedProviderError),
+    ):
         load_llm(provider="some-provider", model="model")
 
 
 @pytest.mark.usefixtures("_registered_fake_provider")
-@patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"])
 def test_load_llm():
     """Test load_llm function."""
-    providers = LLMProviders(
-        [
-            {
-                "name": "fake-provider",
-                "type": "fake-provider",
-                "models": [{"name": "model"}],
-            }
-        ]
-    )
-    config.config.llm_providers = providers
+    with patch("ols.constants.SUPPORTED_PROVIDER_TYPES", new=["fake-provider"]):
+        providers = LLMProviders(
+            [
+                {
+                    "name": "fake-provider",
+                    "type": "fake-provider",
+                    "models": [{"name": "model"}],
+                }
+            ]
+        )
+        config.config.llm_providers = providers
 
-    llm = load_llm(provider="fake-provider", model="model")
-    assert llm == "fake_llm"
+        llm = load_llm(provider="fake-provider", model="model")
+        assert llm == "fake_llm"
 
 
 def test_load_llm_no_provider_config():

--- a/tests/unit/query_helpers/test_docs_summarizer.py
+++ b/tests/unit/query_helpers/test_docs_summarizer.py
@@ -73,117 +73,136 @@ def test_docs_summarizer_streaming_parameter():
     assert summarizer.streaming is True
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_empty_history():
     """Basic test for DocsSummarizer using mocked index and query engine."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
-    history = []  # empty history
-    summary = summarizer.create_response(question, rag_index, history)
-    check_summary_result(summary, question)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 1),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
+        history = []  # empty history
+        summary = summarizer.create_response(question, rag_index, history)
+        check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_no_history():
     """Basic test for DocsSummarizer using mocked index and query engine, no history is provided."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
-    # no history is passed into summarize() method
-    summary = summarizer.create_response(question, rag_index)
-    check_summary_result(summary, question)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
+        # no history is passed into summarize() method
+        summary = summarizer.create_response(question, rag_index)
+        check_summary_result(summary, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_history_provided():
     """Basic test for DocsSummarizer using mocked index and query engine, history is provided."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    history = ["human: What is Kubernetes?"]
-    rag_index = MockLlamaIndex()
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        history = ["human: What is Kubernetes?"]
+        rag_index = MockLlamaIndex()
 
-    # first call with history provided
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
-        return_value=([], False),
-    ) as token_handler:
-        summary1 = summarizer.create_response(question, rag_index, history)
-        token_handler.assert_called_once_with(history, ANY, ANY)
-        check_summary_result(summary1, question)
+        # first call with history provided
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
+            return_value=([], False),
+        ) as token_handler:
+            summary1 = summarizer.create_response(question, rag_index, history)
+            token_handler.assert_called_once_with(history, ANY, ANY)
+            check_summary_result(summary1, question)
 
-    # second call without history provided
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
-        return_value=([], False),
-    ) as token_handler:
-        summary2 = summarizer.create_response(question, rag_index)
-        token_handler.assert_called_once_with([], ANY, ANY)
-        check_summary_result(summary2, question)
+        # second call without history provided
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.TokenHandler.limit_conversation_history",
+            return_value=([], False),
+        ) as token_handler:
+            summary2 = summarizer.create_response(question, rag_index)
+            token_handler.assert_called_once_with([], ANY, ANY)
+            check_summary_result(summary2, question)
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_truncation():
     """Basic test for DocsSummarizer to check if truncation is done."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
 
-    # too long history
-    history = [HumanMessage("What is Kubernetes?")] * 10000
-    summary = summarizer.create_response(question, rag_index, history)
+        # too long history
+        history = [HumanMessage("What is Kubernetes?")] * 10000
+        summary = summarizer.create_response(question, rag_index, history)
 
-    # truncation should be done
-    assert summary.history_truncated
+        # truncation should be done
+        assert summary.history_truncated
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_prepare_prompt_context():
     """Basic test for DocsSummarizer to check re-structuring of context for the 'temp' prompt."""
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    history = [HumanMessage("What is Kubernetes?")]
-    rag_index = MockLlamaIndex()
+    with (
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        history = [HumanMessage("What is Kubernetes?")]
+        rag_index = MockLlamaIndex()
 
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.restructure_rag_context",
-        return_value="patched_history",
-    ) as restructure_rag_context:
-        summarizer.create_response(question, rag_index, history)
-        restructure_rag_context.assert_has_calls([call("sample", ANY)])
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.restructure_rag_context",
+            return_value="patched_history",
+        ) as restructure_rag_context:
+            summarizer.create_response(question, rag_index, history)
+            restructure_rag_context.assert_has_calls([call("sample", ANY)])
 
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.restructure_history",
-        return_value="patched_history",
-    ) as restructure_history:
-        summarizer.create_response(question, rag_index, history)
-        restructure_history.assert_has_calls([call(AIMessage("sample"), ANY)])
+        with patch(
+            "ols.src.query_helpers.docs_summarizer.restructure_history",
+            return_value="patched_history",
+        ) as restructure_history:
+            summarizer.create_response(question, rag_index, history)
+            restructure_history.assert_has_calls([call(AIMessage("sample"), ANY)])
 
 
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_no_reference_content():
     """Basic test for DocsSummarizer using mocked index and query engine."""
-    summarizer = DocsSummarizer(
-        llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
-    )
-    question = "What's the ultimate question with answer 42?"
-    summary = summarizer.create_response(question)
-    assert question in summary.response
-    assert summary.rag_chunks == []
-    assert not summary.history_truncated
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+    ):
+        summarizer = DocsSummarizer(
+            llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
+        )
+        question = "What's the ultimate question with answer 42?"
+        summary = summarizer.create_response(question)
+        assert question in summary.response
+        assert summary.rag_chunks == []
+        assert not summary.history_truncated
 
 
-@patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4)
-@patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3)
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_reranker(caplog):
     """Basic test to make sure the reranker is called as expected."""
     logging_config = LoggingConfig(app_log_level="debug")
@@ -192,30 +211,39 @@ def test_summarize_reranker(caplog):
     logger = logging.getLogger("ols")
     logger.handlers = [caplog.handler]  # add caplog handler to logger
 
-    summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
-    question = "What's the ultimate question with answer 42?"
-    rag_index = MockLlamaIndex()
-    # no history is passed into create_response() method
-    summary = summarizer.create_response(question, rag_index)
-    check_summary_result(summary, question)
+    with (
+        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
+        patch("ols.utils.token_handler.MINIMUM_CONTEXT_TOKEN_LIMIT", 3),
+        patch(
+            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+        ),
+    ):
+        summarizer = DocsSummarizer(llm_loader=mock_llm_loader(None))
+        question = "What's the ultimate question with answer 42?"
+        rag_index = MockLlamaIndex()
+        # no history is passed into create_response() method
+        summary = summarizer.create_response(question, rag_index)
+        check_summary_result(summary, question)
 
-    # Check captured log text to see if reranker was called.
-    assert "reranker.rerank() is called with 1 result(s)." in caplog.text
+        # Check captured log text to see if reranker was called.
+        assert "reranker.rerank() is called with 1 result(s)." in caplog.text
 
 
 @pytest.mark.asyncio
-@patch("ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None))
 async def test_response_generator():
     """Test response generator method."""
-    summarizer = DocsSummarizer(
-        llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
-    )
-    question = "What's the ultimate question with answer 42?"
-    summary_gen = summarizer.generate_response(question)
-    generated_content = ""
+    with patch(
+        "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
+    ):
+        summarizer = DocsSummarizer(
+            llm_loader=mock_llm_loader(mock_langchain_interface("test response")())
+        )
+        question = "What's the ultimate question with answer 42?"
+        summary_gen = summarizer.generate_response(question)
+        generated_content = ""
 
-    async for item in summary_gen:
-        if isinstance(item, str):
-            generated_content += item
+        async for item in summary_gen:
+            if isinstance(item, str):
+                generated_content += item
 
-    assert generated_content == question
+        assert generated_content == question

--- a/tests/unit/query_helpers/test_question_validator.py
+++ b/tests/unit/query_helpers/test_question_validator.py
@@ -63,7 +63,6 @@ def test_passing_parameters():
     )
 
 
-@patch("ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None))
 def test_validate_question_llm_loader():
     """Test that LLM is loaded within validate_question method with proper parameters."""
     # it is needed to initialize configuration in order to be able
@@ -85,8 +84,11 @@ def test_validate_question_llm_loader():
     # check that LLM loader was called with expected parameters
     question_validator = QuestionValidator(llm_loader=llm_loader)
 
-    # just run the validation, we just need to check parameters passed to LLM
-    # that is performed in mock object
-    question_validator.validate_question(
-        "123e4567-e89b-12d3-a456-426614174000", "query"
-    )
+    with patch(
+        "ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None)
+    ):
+        # just run the validation, we just need to check parameters passed to LLM
+        # that is performed in mock object
+        question_validator.validate_question(
+            "123e4567-e89b-12d3-a456-426614174000", "query"
+        )

--- a/tests/unit/query_helpers/test_topic_summarizer.py
+++ b/tests/unit/query_helpers/test_topic_summarizer.py
@@ -54,7 +54,6 @@ def test_prepare_llm():
     assert summarizer.bare_llm is not None
 
 
-@patch("ols.src.query_helpers.topic_summarizer.LLMChain", new=mock_llm_chain(None))
 def test_summarize_topic():
     """Test the summarize_topic method with mocked LLM chain."""
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
@@ -73,15 +72,15 @@ def test_summarize_topic():
         assert response == expected_response
 
 
-@patch("ols.customize.prompts.TOPIC_SUMMARY_PROMPT_TEMPLATE", "")
 def test_skip_summarize_topic():
     """Test topic summarizer is skipped when TOPIC_SUMMARY_PROMPT_TEMPLATE is not set."""
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
-    summarizer = TopicSummarizer(llm_loader=mock_llm_loader(None))
-    response = summarizer.summarize_topic(
-        "123e4567-e89b-12d3-a456-426614174000",
-        "What are the latest developments in artificial intelligence?",
-    )
+    with patch("ols.customize.prompts.TOPIC_SUMMARY_PROMPT_TEMPLATE", ""):
+        summarizer = TopicSummarizer(llm_loader=mock_llm_loader(None))
+        response = summarizer.summarize_topic(
+            "123e4567-e89b-12d3-a456-426614174000",
+            "What are the latest developments in artificial intelligence?",
+        )
 
-    assert response == ""
+        assert response == ""

--- a/tests/unit/rag_index/test_index_loader.py
+++ b/tests/unit/rag_index/test_index_loader.py
@@ -20,69 +20,84 @@ def test_index_loader_empty_config(caplog):
     assert index is None
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-def test_index_loader_no_id(storage_context):
+def test_index_loader_no_id():
     """Test index loader without index id."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+    with patch("llama_index.core.StorageContext.from_defaults"):
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert (
-        index_loader_obj._embed_model == "local:sentence-transformers/all-mpnet-base-v2"
-    )
-    assert index is None
+        assert (
+            index_loader_obj._embed_model
+            == "local:sentence-transformers/all-mpnet-base-v2"
+        )
+        assert index is None
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-@patch("llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir")
-@patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex)
-def test_index_loader(storage_context, from_persist_dir):
+def test_index_loader():
     """Test index loader."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
     config.ols_config.reference_content.product_docs_index_id = "./some_id"
 
-    from_persist_dir.return_value = None
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir"
+        ) as from_persist_dir,
+        patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
+    ):
+        from_persist_dir.return_value = None
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert isinstance(index, MockLlamaIndex)
+        assert isinstance(index, MockLlamaIndex)
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-@patch("llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir")
-@patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex)
-def test_index_loader_from_faiss(storage_context, from_persist_dir):
+def test_index_loader_from_faiss():
     """Test index loader when 'faiss' is selected for the vector store type."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.vector_store_type = VectorStoreType.FAISS
     config.ols_config.reference_content.product_docs_index_path = Path("./some_dir")
     config.ols_config.reference_content.product_docs_index_id = "./some_id"
 
-    from_persist_dir.return_value = None
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.faiss.FaissVectorStore.from_persist_dir"
+        ) as from_persist_dir,
+        patch("llama_index.core.load_index_from_storage", new=MockLlamaIndex),
+    ):
+        from_persist_dir.return_value = None
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert isinstance(index, MockLlamaIndex)
+        assert isinstance(index, MockLlamaIndex)
 
 
-@patch("llama_index.core.StorageContext.from_defaults")
-@patch("llama_index.vector_stores.postgres.PGVectorStore.from_params")
-@patch("llama_index.core.VectorStoreIndex.from_vector_store", new=MockLlamaIndex)
-def test_index_loader_from_postgres(storage_context, from_params):
+def test_index_loader_from_postgres():
     """Test index loader when 'postgres' is selected for the vector store type."""
     config.ols_config.reference_content = ReferenceContent(None)
     config.ols_config.reference_content.vector_store_type = VectorStoreType.POSTGRES
     config.ols_config.reference_content.product_docs_index_id = "some_id"
     config.ols_config.reference_content.postgres = PostgresConfig()
 
-    from_params.return_value = None
+    with (
+        patch("llama_index.core.StorageContext.from_defaults"),
+        patch(
+            "llama_index.vector_stores.postgres.PGVectorStore.from_params"
+        ) as from_params,
+        patch(
+            "llama_index.core.VectorStoreIndex.from_vector_store", new=MockLlamaIndex
+        ),
+    ):
+        from_params.return_value = None
 
-    index_loader_obj = IndexLoader(config.ols_config.reference_content)
-    index = index_loader_obj.vector_index
+        index_loader_obj = IndexLoader(config.ols_config.reference_content)
+        index = index_loader_obj.vector_index
 
-    assert isinstance(index, MockLlamaIndex)
+        assert isinstance(index, MockLlamaIndex)

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -35,80 +35,84 @@ def default_config():
     )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn(mocked_run, default_config):
+def test_start_uvicorn(default_config):
     """Test the function to start Uvicorn server."""
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_with_tls(mocked_run, default_config):
+def test_start_uvicorn_with_tls(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.disable_tls = False
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8443,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8443,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_on_localhost(mocked_run, default_config):
+def test_start_uvicorn_on_localhost(default_config):
     """Test the function to start Uvicorn server."""
     default_config.dev_config.run_on_localhost = True
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="localhost",
-        port=8080,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="localhost",
+            port=8080,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )
 
 
-@patch("uvicorn.run")
-def test_start_uvicorn_on_non_default_port(mocked_run, default_config):
+def test_start_uvicorn_on_non_default_port(default_config):
     """Test the function to start Uvicorn server on a non-default port."""
     default_config.dev_config.uvicorn_port_number = 8081
-    start_uvicorn(default_config)
-    mocked_run.assert_called_once_with(
-        "ols.app.main:app",
-        host="0.0.0.0",  # noqa: S104
-        port=8081,
-        workers=1,
-        log_level=30,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=17,
-        ssl_ciphers="TLSv1",
-        access_log=False,
-    )
+    # don't start real Uvicorn server
+    with patch("uvicorn.run") as mocked_run:
+        start_uvicorn(default_config)
+        mocked_run.assert_called_once_with(
+            "ols.app.main:app",
+            host="0.0.0.0",  # noqa: S104
+            port=8081,
+            workers=1,
+            log_level=30,
+            ssl_keyfile=None,
+            ssl_certfile=None,
+            ssl_keyfile_password=None,
+            ssl_version=17,
+            ssl_ciphers="TLSv1",
+            access_log=False,
+        )

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -693,11 +693,11 @@ dev_config:
     )
 
 
-@patch("os.access", return_value=False)
-def test_unreadable_directory(mock_access):
+def test_unreadable_directory():
     """Check if an unredable directory is reported correctly."""
-    check_expected_exception(
-        """
+    with patch("os.access", return_value=False):
+        check_expected_exception(
+            """
 ---
 llm_providers:
   - name: p1
@@ -720,9 +720,9 @@ dev_config:
   disable_tls: true
 
 """,
-        InvalidConfigurationError,
-        "Embeddings model path 'tests/config' is not readable",
-    )
+            InvalidConfigurationError,
+            "Embeddings model path 'tests/config' is not readable",
+        )
 
 
 def test_valid_config_stream():

--- a/tests/unit/utils/test_environments.py
+++ b/tests/unit/utils/test_environments.py
@@ -7,53 +7,53 @@ from ols.app.models.config import OLSConfig, ReferenceContent
 from ols.utils.environments import configure_gradio_ui_envs, configure_hugging_face_envs
 
 
-@patch.dict(os.environ, {"GRADIO_ANALYTICS_ENABLED": "", "MPLCONFIGDIR": ""})
 def test_configure_gradio_ui_envs():
     """Test the function configure_gradio_ui_envs."""
-    # setup before tested function is called
-    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == ""
-    assert os.environ.get("MPLCONFIGDIR", None) == ""
+    with patch.dict(os.environ, {"GRADIO_ANALYTICS_ENABLED": "", "MPLCONFIGDIR": ""}):
+        # setup before tested function is called
+        assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == ""
+        assert os.environ.get("MPLCONFIGDIR", None) == ""
 
-    # call the tested function
-    configure_gradio_ui_envs()
+        # call the tested function
+        configure_gradio_ui_envs()
 
-    # expected environment variables
-    assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == "false"
-    assert os.environ.get("MPLCONFIGDIR", None) != ""
+        # expected environment variables
+        assert os.environ.get("GRADIO_ANALYTICS_ENABLED", None) == "false"
+        assert os.environ.get("MPLCONFIGDIR", None) != ""
 
 
-@patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""})
 def test_configure_hugging_face_env_no_reference_content_set():
     """Test the function configure_hugging_face_envs."""
-    # setup before tested function is called
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+    with patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""}):
+        # setup before tested function is called
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
-    ols_config = OLSConfig()
-    ols_config.reference_content = None
+        ols_config = OLSConfig()
+        ols_config.reference_content = None
 
-    # call the tested function
-    configure_hugging_face_envs(ols_config)
+        # call the tested function
+        configure_hugging_face_envs(ols_config)
 
-    # expected environment variables
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+        # expected environment variables
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
 
-@patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""})
 def test_configure_hugging_face_env_reference_content_set():
     """Test the function configure_hugging_face_envs."""
-    # setup before tested function is called
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
+    with patch.dict(os.environ, {"TRANSFORMERS_CACHE": "", "TRANSFORMERS_OFFLINE": ""}):
+        # setup before tested function is called
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == ""
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == ""
 
-    ols_config = OLSConfig()
-    ols_config.reference_content = ReferenceContent()
-    ols_config.reference_content.embeddings_model_path = "foo"
+        ols_config = OLSConfig()
+        ols_config.reference_content = ReferenceContent()
+        ols_config.reference_content.embeddings_model_path = "foo"
 
-    # call the tested function
-    configure_hugging_face_envs(ols_config)
+        # call the tested function
+        configure_hugging_face_envs(ols_config)
 
-    # expected environment variables
-    assert os.environ.get("TRANSFORMERS_CACHE", None) == "foo"
-    assert os.environ.get("TRANSFORMERS_OFFLINE", None) == "1"
+        # expected environment variables
+        assert os.environ.get("TRANSFORMERS_CACHE", None) == "foo"
+        assert os.environ.get("TRANSFORMERS_OFFLINE", None) == "1"


### PR DESCRIPTION
## Description

Removed all remaining `@patch` decorators from unit tests
Fixes: #427

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests
