### PR TITLE
OLS-1615: Get rid of LLMChain in llm loader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,8 +228,7 @@ It is possible to use patching inside the test implementation as a context manag
 
 ```python
 def test_xyz():
-    ml = mock_llm_chain({"text": retval})
-    with patch("ols.src.query_helpers.question_validator.LLMChain", new=ml):
+    with patch("ols.config", new=Mock()):
         ...
         ...
         ...

--- a/ols/src/llms/llm_loader.py
+++ b/ols/src/llms/llm_loader.py
@@ -77,7 +77,7 @@ def load_llm(
 
         bare_llm = load_llm(provider="openai", model="gpt-4o-mini",
                             generic_llm_params=generic_llm_params).llm
-        llm_chain = LLMChain(llm=bare_llm, prompt=prompt)
+        llm_chain = prompt | bare_llm
         ```
     """
     providers_config = config.config.llm_providers


### PR DESCRIPTION
## Description

OLS-1615: Get rid of LLMChain in llm loader

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #OLS-1615
