### PR TITLE
enhance summarizer prompt to make it consistent

### DIFF
--- a/ols/customize/ols/prompts.py
+++ b/ols/customize/ols/prompts.py
@@ -81,10 +81,15 @@ For Input Analysis:
 
 For Output Constraints:
 - Maximum 5 words
-- Uppercase first letter of significant words
-- Avoid articles prepositions
-- Exclude punctuation
+- Capitalize only significant words (e.g., nouns, verbs, adjectives, adverbs).
+- Do not use all uppercase - capitalize only the first letter of significant words
+- Exclude articles, prepositions, and punctuation (e.g., "a," "the," "of," "on," "in")
 - Neutral objective language
+
+Examples:
+- "AI Capabilities Summary" (Correct)
+- "Machine Learning Applications" (Correct)
+- "AI CAPABILITIES SUMMARY" (Incorrect—should not be fully uppercase)
 
 Processing Steps
 1. Analyze semantic structure


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

before this change, with different models, the topic summary was returned inconsistent, some only Uppercase significant words, some will be all capitalized, e.g.
![Screenshot 2025-03-27 at 2 02 47 PM](https://github.com/user-attachments/assets/c59bed6e-d1ab-4668-a281-45c101f7c51c)

This PR updates the summarizer prompt to make the output more consistent, also gives examples on correct and incorrect output


## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/RHDHPAI-723

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
