### PR TITLE
No LLMChain mock in benchmarks

### DIFF
--- a/tests/benchmarks/test_docs_summarizer.py
+++ b/tests/benchmarks/test_docs_summarizer.py
@@ -11,7 +11,6 @@ from ols import config
 from ols.utils import suid
 from tests.mock_classes.mock_langchain_interface import mock_langchain_interface
 from tests.mock_classes.mock_llama_index import MockLlamaIndex
-from tests.mock_classes.mock_llm_chain import mock_llm_chain
 from tests.mock_classes.mock_llm_loader import mock_llm_loader
 
 conversation_id = suid.get_suid()
@@ -52,12 +51,7 @@ def test_summarize_empty_history(benchmark, rag_index, summarizer):
     question = "What's the ultimate question with answer 42?"
     history = []  # empty history
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # run the benchmark
         benchmark(summarizer.create_response, question, rag_index, history)
 
@@ -66,12 +60,7 @@ def test_summarize_no_history(benchmark, rag_index, summarizer):
     """Benchmark for DocsSummarizer using mocked index and query engine, no history is provided."""
     question = "What's the ultimate question with answer 42?"
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # no history is passed into summarize() method
         # run the benchmark
         benchmark(summarizer.create_response, question, rag_index)
@@ -82,12 +71,7 @@ def test_summarize_history_provided(benchmark, rag_index, summarizer):
     question = "What's the ultimate question with answer 42?"
     history = [HumanMessage("What is Kubernetes?")]
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # first call with history provided
         benchmark(summarizer.create_response, question, rag_index, history)
 
@@ -99,12 +83,7 @@ def test_summarize_history_truncation(benchmark, rag_index, summarizer):
     # too long history
     history = [HumanMessage("What is Kubernetes?")] * 10
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # run the benchmark
         benchmark(summarizer.create_response, question, rag_index, history)
 
@@ -122,12 +101,7 @@ def test_summarize_too_long_question(benchmark, rag_index, summarizer):
     # short history
     history = ["What is Kubernetes?"]
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # run the benchmark
         benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
@@ -139,12 +113,7 @@ def test_summarize_too_long_question_long_history(benchmark, rag_index, summariz
     # too long history
     history = ["What is Kubernetes?"] * 10000
 
-    with (
-        patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4),
-        patch(
-            "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-        ),
-    ):
+    with patch("ols.utils.token_handler.RAG_SIMILARITY_CUTOFF", 0.4):
         # run the benchmark
         benchmark(try_to_run_summarizer, summarizer, question, rag_index, history)
 
@@ -153,8 +122,5 @@ def test_summarize_no_reference_content(benchmark, summarizer_no_reference_conte
     """Benchmark for DocsSummarizer using mocked index and query engine."""
     question = "What's the ultimate question with answer 42?"
 
-    with patch(
-        "ols.src.query_helpers.docs_summarizer.LLMChain", new=mock_llm_chain(None)
-    ):
-        # run the benchmark
-        benchmark(summarizer_no_reference_content.create_response, question)
+    # run the benchmark
+    benchmark(summarizer_no_reference_content.create_response, question)

--- a/tests/benchmarks/test_question_validator.py
+++ b/tests/benchmarks/test_question_validator.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from langchain_core.messages import AIMessage
+
 from ols import config
 from ols.constants import GenericLLMParameters
 
@@ -9,7 +11,6 @@ from ols.constants import GenericLLMParameters
 config.ols_config.authentication_config.module = "k8s"
 
 from ols.src.query_helpers.question_validator import QuestionValidator  # noqa: E402
-from tests.mock_classes.mock_llm_chain import mock_llm_chain  # noqa: E402
 from tests.mock_classes.mock_llm_loader import mock_llm_loader  # noqa: E402
 
 
@@ -20,8 +21,10 @@ def perform_question_validation_benchmark(benchmark, question):
     config.reload_from_yaml_file("tests/config/valid_config.yaml")
 
     with patch(
-        "ols.src.query_helpers.question_validator.LLMChain", new=mock_llm_chain(None)
-    ):
+        "ols.src.query_helpers.question_validator.QuestionValidator._invoke_llm"
+    ) as mock_invoke:
+        mock_invoke.return_value = AIMessage(content="ACCEPTED")
+
         # when the LLM will be initialized the check for provided parameters will
         # be performed
         llm_loader = mock_llm_loader(
@@ -30,7 +33,6 @@ def perform_question_validation_benchmark(benchmark, question):
                 "p1",
                 "m1",
                 {GenericLLMParameters.MAX_TOKENS_FOR_RESPONSE: 4},
-                False,
             ),
         )
 


### PR DESCRIPTION
## Description

No `LLMChain` mock in benchmarks

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
