### PR TITLE
Changing the default make target to be the help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MODEL := $(if $(MODEL),$(MODEL),"gpt-4o-mini")
 # Python registry to where the package should be uploaded
 PYTHON_REGISTRY = testpypi
 
+default: help
 
 images: ## Build container images
 	scripts/build-container.sh


### PR DESCRIPTION
## Description

Changing the default `make` target to be the `help`

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
