### PR TITLE
Add Model Check Disabling Feature To RHDH Config Parsing

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -540,27 +540,28 @@ class LLMProviders(BaseModel):
         """Private helper for converting RHDH config file model data to RCS readable data."""
         all_converted_providers = []
         for server in data:
+            disable_model_check = False
             formatted_data = {}
             name = server.get("id")
             url = server.get("url")
-            models = server.get(
-                "models"
-            )  # OLS doesn't require model_name but is a requirement of road-core config.
+            models = server.get("models")
             model_type = server.get("type")
             token = server.get("token")
             if name is None:
                 raise KeyError("lightspeed id is missing.")
             if url is None:
                 raise KeyError("lightspeed url is missing.")
-            if models is None:
-                raise KeyError("lightspeed models missing.")
             if token is None:
                 raise KeyError("lightspeed token is missing.")
+            if models is None:
+                models = {}
+                disable_model_check = True
             if model_type is None:
                 model_type = "openai"  # Default to openai if type is unset.
             formatted_data["name"] = name
             formatted_data["url"] = url
             formatted_data["models"] = models
+            formatted_data["disable_model_check"] = disable_model_check
             formatted_data["type"] = model_type
             provider = ProviderConfig(formatted_data, True)
             provider.credentials = token

--- a/tests/config/valid_rhdh_config_multiple_providers.yaml
+++ b/tests/config/valid_rhdh_config_multiple_providers.yaml
@@ -83,8 +83,6 @@ lightspeed:
     - id: ollama
       url: http://localhost:11434/v1
       token: placeholder-token
-      models:
-        - name: model-one
     - id: new-cluster
       url: http://localhost:8080
       token: my-token

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4158,21 +4158,6 @@ def test_missing_lightspeed_url_attribute():
         config._parse_rhdh_lightspeed_config(data)
 
 
-def test_missing_lightspeed_models_attribute():
-    """Test if missing model name attribute is handled correctly."""
-    config = LLMProviders()
-    data = [
-        {
-            "id": "lightspeed-id",
-            "url": "lightspeed-url",
-            "type": "lightspeed-type",
-            "token": "lightspeed-token",
-        }
-    ]
-    with pytest.raises(KeyError, match="lightspeed models missing."):
-        config._parse_rhdh_lightspeed_config(data)
-
-
 def test_missing_lightspeed_token_attribute():
     """Test if missing token attribute is handled correctly."""
     config = LLMProviders()
@@ -4224,14 +4209,40 @@ def test_lightspeed_token_setting():
     )
 
 
+def test_lightspeed_model_check_disabled_setting():
+    """Test if the model check disabled field is properly set for a lightspeed provider."""
+    config = LLMProviders()
+    data = [
+        {
+            "id": "lightspeed-id",
+            "url": "lightspeed-url",
+            "models": [{"name": "lightspeed-model-name"}],
+            "token": "lightspeed-token",
+            "type": "openai",
+        },
+        {
+            "id": "lightspeed-id-two",
+            "url": "lightspeed-url-two",
+            "token": "lightspeed-token-two",
+            "type": "openai",
+        },
+    ]
+
+    parsed_providers = config._parse_rhdh_lightspeed_config(data)
+    assert (
+        parsed_providers[0].disable_model_check is False
+        and parsed_providers[1].disable_model_check is True
+    )
+
+
 def test_lightspeed_config_parsing():
     """Test if the parsing of lightspeed providers from an RHDH config file is handled properly."""
     provider_one = ProviderConfig(
         {
             "name": "ollama",
             "url": "http://localhost:11434/v1",
-            "models": [{"name": "model-one"}],
             "type": "openai",
+            "disable_model_check": True,
         },
         True,
     )


### PR DESCRIPTION
## Description

As part of the changes in https://github.com/road-core/service/pull/482 the ability to disable the model check was added. In order to incorporate that change with the parsing of Lightspeed configuration files I had to make a few tweaks.

This work is tracked in https://issues.redhat.com/browse/RHDHPAI-719
<!--- Describe your changes in detail -->

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/RHDHPAI-719
- Closes # https://issues.redhat.com/browse/RHDHPAI-719

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Updated the unit tests in place to reflect the new functionality, also ran through e2e on OpenShift to make sure it reads as expected.