### PR TITLE
fix the model config is not defined bug in question validator

### DIFF
--- a/ols/src/query_helpers/question_validator.py
+++ b/ols/src/query_helpers/question_validator.py
@@ -87,10 +87,10 @@ class QuestionValidator(QueryHelper):
         # Tokens-check: We trigger the computation of the token count
         # without care about the return value. This is to ensure that
         # the query is within the token limit.
-        provider_config = config.llm_config.providers.get(self.provider)
-        model_config = provider_config.models.get(self.model)
-        if provider_config.disable_model_check and model_config is None:
-            model_config = provider_config.models.get(DEFAULT_MODEL_NAME)
+        self.provider_config = config.llm_config.providers.get(self.provider)
+        self.model_config = self.provider_config.models.get(self.model)
+        if self.provider_config.disable_model_check and self.model_config is None:
+            self.model_config = self.provider_config.models.get(DEFAULT_MODEL_NAME)
         TokenHandler().calculate_and_check_available_tokens(
             query, self.model_config.context_window_size, self.max_tokens_for_response
         )


### PR DESCRIPTION
## Description

fix the model config is not defined bug in question validator when `disable_model_check: true` is set for a llm provider.
the `self.model_config` and `self.provider_config` should be referenced as it's been set in `__init__()`


## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

To test the change, remove model list in a provider and set `disable_model_check: true` in rsconfig. 
also enable the question validator by setting `query_validation_method: llm`
test with and without the PR change