### PR TITLE
Disable query_validation from sample configs

### DIFF
--- a/examples/rcsconfig-local-ollama.yaml
+++ b/examples/rcsconfig-local-ollama.yaml
@@ -32,7 +32,6 @@ ols_config:
     uvicorn_log_level: info
   default_provider: ollama
   default_model: 'llama3.1:latest'
-  query_validation_method: llm
   user_data_collection:
     feedback_disabled: false
     feedback_storage: "/tmp/data/feedback"

--- a/examples/rcsconfig-pgvector.yaml
+++ b/examples/rcsconfig-pgvector.yaml
@@ -29,7 +29,6 @@ ols_config:
   default_model: 'llama3.2'
   expire_llm_is_ready_persistent_state: -1
   enable_event_stream_format: true
-  query_validation_method: llm
 dev_config:
   # config options specific to dev environment - launching OLS in local
   enable_dev_ui: true

--- a/examples/rcsconfig.yaml
+++ b/examples/rcsconfig.yaml
@@ -84,8 +84,8 @@ ols_config:
   # supported values:
   #     "keyword"  - keyword based query validation (see ols/utils/keywords.py)
   #     "llm"      - LLM based query validation
-  #     "disabled" - question validation is disabled (all questions will be marked as valid)
-  query_validation_method: llm
+  #     "disabled" - The default. Question validation is disabled (all questions will be marked as valid)
+  query_validation_method: disabled
   authentication_config:
     module: "k8s"
     k8s_cluster_api: "https://api.example.com:6443"


### PR DESCRIPTION
## Description
The query validation has been disabled by default in the code since the commit a7a0cc7706fb4d587eb4e4989630477d907c9a4b but, we left it enabled in the sample configuration files, which can cause some confusion for people that are experimenting with the project.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

Not applicable

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Not applicable, just sample configuration files to match the default configurations of the code.