### PR TITLE
Remove models from lightspeed config in rhdh parsing

### DIFF
--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -544,11 +544,9 @@ class LLMProviders(BaseModel):
         """Private helper for converting RHDH config file model data to RCS readable data."""
         all_converted_providers = []
         for server in data:
-            disable_model_check = False
             formatted_data = {}
             name = server.get("id")
             url = server.get("url")
-            models = server.get("models")
             model_type = server.get("type")
             token = server.get("token")
             if name is None:
@@ -557,15 +555,11 @@ class LLMProviders(BaseModel):
                 raise KeyError("lightspeed url is missing.")
             if token is None:
                 raise KeyError("lightspeed token is missing.")
-            if models is None:
-                models = {}
-                disable_model_check = True
             if model_type is None:
                 model_type = "openai"  # Default to openai if type is unset.
             formatted_data["name"] = name
             formatted_data["url"] = url
-            formatted_data["models"] = models
-            formatted_data["disable_model_check"] = disable_model_check
+            formatted_data["disable_model_check"] = True
             formatted_data["type"] = model_type
             provider = ProviderConfig(formatted_data, True)
             provider.credentials = token

--- a/tests/config/valid_rhdh_config.yaml
+++ b/tests/config/valid_rhdh_config.yaml
@@ -83,5 +83,3 @@ lightspeed:
     - id: ollama
       url: http://localhost:11434/v1
       token: placeholder-token
-      models:
-        - name: model-one

--- a/tests/config/valid_rhdh_config_multiple_providers.yaml
+++ b/tests/config/valid_rhdh_config_multiple_providers.yaml
@@ -86,5 +86,3 @@ lightspeed:
     - id: new-cluster
       url: http://localhost:8080
       token: my-token
-      models:
-        - name: model-one

--- a/tests/unit/app/models/test_config.py
+++ b/tests/unit/app/models/test_config.py
@@ -4133,7 +4133,6 @@ def test_missing_lightspeed_id_attribute():
     data = [
         {
             "url": "lightspeed-url",
-            "models": [{"name": "lightspeed-model-name"}],
             "type": "lightspeed-type",
             "token": "lightspeed-token",
         }
@@ -4149,7 +4148,6 @@ def test_missing_lightspeed_url_attribute():
     data = [
         {
             "id": "lightspeed-id",
-            "models": [{"name": "lightspeed-model-name"}],
             "type": "lightspeed-type",
             "token": "lightspeed-token",
         }
@@ -4165,7 +4163,6 @@ def test_missing_lightspeed_token_attribute():
         {
             "id": "lightspeed-id",
             "url": "lightspeed-url",
-            "models": [{"name": "lightspeed-model-name"}],
             "type": "lightspeed-type",
         }
     ]
@@ -4180,7 +4177,6 @@ def test_missing_lightspeed_type_attribute():
         {
             "id": "lightspeed-id",
             "url": "lightspeed-url",
-            "models": [{"name": "lightspeed-model-name"}],
             "token": "lightspeed-token",
         }
     ]
@@ -4196,7 +4192,6 @@ def test_lightspeed_token_setting():
         {
             "id": "lightspeed-id",
             "url": "lightspeed-url",
-            "models": [{"name": "lightspeed-model-name"}],
             "token": "lightspeed-token",
             "type": "openai",
         }
@@ -4216,7 +4211,6 @@ def test_lightspeed_model_check_disabled_setting():
         {
             "id": "lightspeed-id",
             "url": "lightspeed-url",
-            "models": [{"name": "lightspeed-model-name"}],
             "token": "lightspeed-token",
             "type": "openai",
         },
@@ -4230,7 +4224,7 @@ def test_lightspeed_model_check_disabled_setting():
 
     parsed_providers = config._parse_rhdh_lightspeed_config(data)
     assert (
-        parsed_providers[0].disable_model_check is False
+        parsed_providers[0].disable_model_check is True
         and parsed_providers[1].disable_model_check is True
     )
 
@@ -4250,8 +4244,8 @@ def test_lightspeed_config_parsing():
         {
             "name": "new-cluster",
             "url": "http://localhost:8080",
-            "models": [{"name": "model-one"}],
             "type": "openai",
+            "disable_model_check": True,
         },
         True,
     )


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This change removes the `models` field from being recognized when parsing RHDH config. With how OLS works there will never be a `models` field in the yaml. Because of this, all providers parsed from OLS will have the model check disabled as the models are accessed via /models endpoint.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue # N/A
- Closes # N/A

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
