### PR TITLE
OLS-1714: reconnect Postgres quota DB when tables are deleted

### DIFF
--- a/ols/src/quota/cluster_quota_limiter.py
+++ b/ols/src/quota/cluster_quota_limiter.py
@@ -22,11 +22,5 @@ class ClusterQuotaLimiter(RevokableQuotaLimiter):
         super().__init__(initial_quota, increase_by, subject, config)
 
         # initialize connection to DB
+        # and initialize tables too
         self.connect()
-
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise

--- a/ols/src/quota/quota_limiter.py
+++ b/ols/src/quota/quota_limiter.py
@@ -42,6 +42,10 @@ class QuotaLimiter(ABC):
         """Initialize connection config."""
         self.connection_config: Optional[PostgresConfig] = None
 
+    @abstractmethod
+    def _initialize_tables(self) -> None:
+        """Initialize tables and indexes."""
+
     # pylint: disable=W0201
     def connect(self) -> None:
         """Initialize connection to database."""
@@ -59,6 +63,14 @@ class QuotaLimiter(ABC):
             # sslrootcert=config.ca_cert_path,
             gssencmode=config.gss_encmode,
         )
+
+        try:
+            self._initialize_tables()
+        except Exception as e:
+            self.connection.close()
+            logger.exception("Error initializing Postgres database:\n%s", e)
+            raise
+
         self.connection.autocommit = True
 
     def connected(self) -> bool:

--- a/ols/src/quota/revokable_quota_limiter.py
+++ b/ols/src/quota/revokable_quota_limiter.py
@@ -150,6 +150,7 @@ class RevokableQuotaLimiter(QuotaLimiter):
 
     def _initialize_tables(self) -> None:
         """Initialize tables used by quota limiter."""
+        logger.info("Initializing tables for quota limiter")
         cursor = self.connection.cursor()
         cursor.execute(RevokableQuotaLimiter.CREATE_QUOTA_TABLE)
         cursor.close()

--- a/ols/src/quota/token_usage_history.py
+++ b/ols/src/quota/token_usage_history.py
@@ -54,13 +54,6 @@ class TokenUsageHistory:
         # initialize connection to DB
         self.connect()
 
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise
-
     @connection
     def consume_tokens(
         self,
@@ -111,6 +104,12 @@ class TokenUsageHistory:
             # sslrootcert=config.ca_cert_path,
             gssencmode=config.gss_encmode,
         )
+        try:
+            self._initialize_tables()
+        except Exception as e:
+            self.connection.close()
+            logger.exception("Error initializing Postgres database:\n%s", e)
+            raise
         self.connection.autocommit = True
 
     def connected(self) -> bool:
@@ -129,6 +128,7 @@ class TokenUsageHistory:
 
     def _initialize_tables(self) -> None:
         """Initialize tables used by quota limiter."""
+        logger.info("Initializing tables for token usage history")
         cursor = self.connection.cursor()
         cursor.execute(TokenUsageHistory.CREATE_TOKEN_USAGE_TABLE)
         cursor.close()

--- a/ols/src/quota/user_quota_limiter.py
+++ b/ols/src/quota/user_quota_limiter.py
@@ -22,11 +22,5 @@ class UserQuotaLimiter(RevokableQuotaLimiter):
         super().__init__(initial_quota, increase_by, subject, config)
 
         # initialize connection to DB
+        # and initialize tables too
         self.connect()
-
-        try:
-            self._initialize_tables()
-        except Exception as e:
-            self.connection.close()
-            logger.exception("Error initializing Postgres database:\n%s", e)
-            raise

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -246,7 +246,7 @@ def test_insert_or_append_operation():
         ),
         call(PostgresCache.QUERY_CACHE_SIZE),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
 def test_insert_or_append_operation_append_item():
@@ -292,7 +292,7 @@ def test_insert_or_append_operation_append_item():
             (new_conversation.encode("utf-8"), user_id, conversation_id),
         ),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
 def test_insert_or_append_operation_on_exception():
@@ -358,7 +358,7 @@ def test_insert_or_append_operation_on_disconnected_db():
         call(PostgresCache.QUERY_CACHE_SIZE),
         call("SELECT 1"),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
 def test_list_operation():
@@ -622,7 +622,7 @@ def test_cleanup_method_when_clean_performed():
             PostgresCache.DELETE_CONVERSATION_HISTORY_STATEMENT + " 100)",
         ),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
 def test_ready():

--- a/tests/unit/quota/test_cluster_quota_limiter.py
+++ b/tests/unit/quota/test_cluster_quota_limiter.py
@@ -138,7 +138,7 @@ def test_available_quota_no_data():
             ("", subject, quota_limit, quota_limit, timestamp),
         ),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
     assert available == quota_limit
 
 

--- a/tests/unit/quota/test_token_usage_history.py
+++ b/tests/unit/quota/test_token_usage_history.py
@@ -79,7 +79,7 @@ def test_consume_tokens():
             },
         ),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
 
 
 def test_consume_tokens_on_disconnected_db():
@@ -125,8 +125,6 @@ def test_consume_tokens_on_disconnected_db():
 
     # expected calls to storage
     calls = [
-        # check if storage connection is alive
-        call("SELECT 1"),
         # quota for given user should be read from storage
         # and the initialization of new record should be made
         call(
@@ -140,5 +138,7 @@ def test_consume_tokens_on_disconnected_db():
                 "updated_at": timestamp,
             },
         ),
+        # check if storage connection is alive
+        call("SELECT 1"),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)

--- a/tests/unit/quota/test_user_quota_limiter.py
+++ b/tests/unit/quota/test_user_quota_limiter.py
@@ -145,7 +145,7 @@ def test_available_quota_no_data():
             (user_id, subject, quota_limit, quota_limit, timestamp),
         ),
     ]
-    mock_cursor.execute.assert_has_calls(calls, any_order=True)
+    mock_cursor.execute.assert_has_calls(calls, any_order=False)
     assert available == quota_limit
 
 


### PR DESCRIPTION
## Description

OLS-1714: reconnect Postgres quota DB when tables are deleted

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change


## Related Tickets & Documents

- Related Issue #OLS-1714
