### PR TITLE
[minor] Silence Pyright's improper linting error

### DIFF
--- a/tests/integration/test_authorized.py
+++ b/tests/integration/test_authorized.py
@@ -1,5 +1,9 @@
 """Integration tests for /livenss and /readiness REST API endpoints."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 import logging
 from unittest.mock import patch
 

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -1,5 +1,9 @@
 """Integration tests for /conversations REST API endpoints."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -1,5 +1,9 @@
 """Integration tests for REST API endpoints for providing user feedback."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/integration/test_liveness_readiness.py
+++ b/tests/integration/test_liveness_readiness.py
@@ -1,5 +1,9 @@
 """Integration tests for /livenss and /readiness REST API endpoints."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 import os
 from unittest.mock import patch
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,5 +1,9 @@
 """Integration tests for metrics exposed by the service."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 import logging
 import os
 import re

--- a/tests/integration/test_ols.py
+++ b/tests/integration/test_ols.py
@@ -1,5 +1,9 @@
 """Integration tests for basic OLS REST API endpoints."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 import logging
 from unittest.mock import patch
 

--- a/tests/integration/test_openapi.py
+++ b/tests/integration/test_openapi.py
@@ -1,5 +1,9 @@
 """Integration tests for REST API endpoint that provides OpenAPI specification."""
 
+# we add new attributes into pytest instance, which is not recognized
+# properly by linters
+# pyright: reportAttributeAccessIssue=false
+
 import json
 import os
 from unittest.mock import patch


### PR DESCRIPTION
## Description

[minor] Silence Pyright's improper linting error
Pyright is not able to figure out new `pytest` attribute

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
