### PR TITLE
LCORE-148: add configurable metrics

### DIFF
--- a/ols/app/main.py
+++ b/ols/app/main.py
@@ -44,6 +44,7 @@ else:
 
 # update provider and model as soon as possible so the metrics will be visible
 # even for first scraping
+metrics.setup_metrics(config)
 metrics.setup_model_metrics(config)
 
 

--- a/ols/app/metrics/__init__.py
+++ b/ols/app/metrics/__init__.py
@@ -10,6 +10,7 @@ from .metrics import (
     response_duration_seconds,
     rest_api_calls_total,
     setup_model_metrics,
+    setup_metrics,
 )
 from .token_counter import GenericTokenCounter, TokenMetricUpdater
 
@@ -25,4 +26,5 @@ __all__ = [
     "response_duration_seconds",
     "rest_api_calls_total",
     "setup_model_metrics",
+    "setup_metrics",
 ]

--- a/ols/app/models/config.py
+++ b/ols/app/models/config.py
@@ -1015,6 +1015,8 @@ class OLSConfig(BaseModel):
 
     quota_handlers: Optional[QuotaHandlersConfig] = None
 
+    metrics: Optional[list[str]] = []
+
     def __init__(
         self, data: Optional[dict] = None, ignore_missing_certs: bool = False
     ) -> None:
@@ -1066,6 +1068,7 @@ class OLSConfig(BaseModel):
             data.get("tlsSecurityProfile", None)
         )
         self.quota_handlers = QuotaHandlersConfig(data.get("quota_handlers", None))
+        self.metrics = data.get("metrics", [])
 
     def __eq__(self, other: object) -> bool:
         """Compare two objects for equality."""


### PR DESCRIPTION
## Description

Introduce ability to configure in config file which prometheus metrics are available at `/metrics` endpoint
for scraping:
* optional config for metrics looks like this - list of metrics that should be kept enabled
* by default all metrics are kept enabled (no specific metrics in config file mentioned)
* case invalid metric name in config file - a warning is printed

## Type of change

- [*] Refactor
- [*] New feature


## Related Tickets & Documents

- Related Issue #LCORE-148
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
