### PR TITLE
Store the RAG data as part of conversation history

### DIFF
--- a/ols/app/endpoints/ols.py
+++ b/ols/app/endpoints/ols.py
@@ -125,6 +125,7 @@ def conversation_request(
         processed_request.conversation_id,
         llm_request,
         summarizer_response.response,
+        summarizer_response.rag_chunks,
         processed_request.attachments,
         processed_request.timestamps,
         topic_summary,
@@ -556,6 +557,7 @@ def store_conversation_history(
     conversation_id: str,
     llm_request: LLMRequest,
     response: Optional[str],
+    rag_chunks: list[RagChunk],
     attachments: list[Attachment],
     timestamps: dict[str, float],
     topic_summary: str,
@@ -584,6 +586,8 @@ def store_conversation_history(
                 response_message.response_metadata["provider"] = llm_request.provider
             if llm_request.model:
                 response_message.response_metadata["model"] = llm_request.model
+            if rag_chunks:
+                response_message.additional_kwargs["reference_documents"] = build_referenced_docs(rag_chunks)
 
             cache_entry = CacheEntry(
                 query=query_message,
@@ -760,6 +764,17 @@ def construct_transcripts_path(user_id: str, conversation_id: str) -> Path:
         uid,
         cid,
     )
+    
+def build_referenced_docs(rag_chunks: list[RagChunk]) -> list[dict]:
+    """Build a list of unique referenced documents."""
+    referenced_documents = ReferencedDocument.from_rag_chunks(rag_chunks)
+    return [
+        {
+            "doc_title": document.doc_title,
+            "doc_url": document.doc_url,
+        }
+        for document in referenced_documents
+    ]
 
 
 def store_transcript(

--- a/ols/app/endpoints/streaming_ols.py
+++ b/ols/app/endpoints/streaming_ols.py
@@ -24,6 +24,7 @@ from ols.app.endpoints.ols import (
     process_request,
     store_conversation_history,
     store_transcript,
+    build_referenced_docs,
 )
 from ols.app.models.models import (
     Attachment,
@@ -191,18 +192,6 @@ def stream_end_event(
     return f"\n\n---\n\n{ref_docs_string}" if ref_docs_string else ""
 
 
-def build_referenced_docs(rag_chunks: list[RagChunk]) -> list[dict]:
-    """Build a list of unique referenced documents."""
-    referenced_documents = ReferencedDocument.from_rag_chunks(rag_chunks)
-    return [
-        {
-            "doc_title": document.doc_title,
-            "doc_url": document.doc_url,
-        }
-        for document in referenced_documents
-    ]
-
-
 def prompt_too_long_error(error: PromptTooLongError, media_type: str) -> str:
     """Return error representation for long prompts.
 
@@ -311,6 +300,7 @@ def store_data(
         conversation_id,
         llm_request,
         response,
+        rag_chunks,
         attachments,
         timestamps,
         topic_summary,

--- a/tests/unit/app/endpoints/test_ols.py
+++ b/tests/unit/app/endpoints/test_ols.py
@@ -232,6 +232,7 @@ def test_store_conversation_history():
             llm_request,
             response,
             [],
+            [],
             {},
             topic_summary,
         )
@@ -259,7 +260,7 @@ def test_store_conversation_history_some_response():
 
     with patch("ols.config.conversation_cache.insert_or_append") as insert_or_append:
         ols.store_conversation_history(
-            user_id, conversation_id, llm_request, response, [], {}, topic_summary
+            user_id, conversation_id, llm_request, response, [], [], {}, topic_summary
         )
 
         expected_history = CacheEntry(
@@ -284,6 +285,13 @@ def test_store_conversation_history_store_metadata():
     model = "some-model"
     llm_request = LLMRequest(query=query, provider=provider, model=model)
     response = "*response*"
+    mock_rag_chunk = [
+            RagChunk(text="text1", doc_url="url-b", doc_title="title-b"),
+            RagChunk(
+                text="text2", doc_url="url-b", doc_title="title-b"
+            ),  # duplicate doc
+            RagChunk(text="text3", doc_url="url-a", doc_title="title-a"),
+        ]
     skip_user_id_check = False
     start_time = time.time()
     response_time = time.time()
@@ -296,6 +304,7 @@ def test_store_conversation_history_store_metadata():
             conversation_id,
             llm_request,
             response,
+            mock_rag_chunk,
             [],
             timestamps,
             topic_summary,
@@ -311,6 +320,18 @@ def test_store_conversation_history_store_metadata():
                     "created_at": response_time,
                     "model": model,
                     "provider": provider,
+                },
+                additional_kwargs={
+                    "reference_documents": [
+                        {
+                            "doc_title": "title-b",
+                            "doc_url": "url-b"
+                        },
+                        {
+                            "doc_title": "title-a",
+                            "doc_url": "url-a"
+                        }
+                    ]
                 },
             ),
         )
@@ -331,11 +352,11 @@ def test_store_conversation_history_empty_user_id():
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     with pytest.raises(HTTPException, match="Invalid user ID"):
         ols.store_conversation_history(
-            user_id, conversation_id, llm_request, "", [], {}, ""
+            user_id, conversation_id, llm_request, "", [], [], {}, ""
         )
     with pytest.raises(HTTPException, match="Invalid user ID"):
         ols.store_conversation_history(
-            user_id, conversation_id, llm_request, None, [], {}, ""
+            user_id, conversation_id, llm_request, None, [], [], {}, ""
         )
 
 
@@ -347,7 +368,7 @@ def test_store_conversation_history_improper_user_id():
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     with pytest.raises(HTTPException, match="Invalid user ID"):
         ols.store_conversation_history(
-            user_id, conversation_id, llm_request, "", [], {}, ""
+            user_id, conversation_id, llm_request, "", [], [], {}, ""
         )
 
 
@@ -358,7 +379,7 @@ def test_store_conversation_history_improper_conversation_id():
     llm_request = LLMRequest(query="Tell me about Kubernetes")
     with pytest.raises(HTTPException, match="Invalid conversation ID"):
         ols.store_conversation_history(
-            constants.DEFAULT_USER_UID, conversation_id, llm_request, "", [], {}, ""
+            constants.DEFAULT_USER_UID, conversation_id, llm_request, "", [], [], {}, ""
         )
 
 
@@ -1448,3 +1469,17 @@ def test_get_available_quotas_two_quota_limiters():
         "MockQuotaLimiter1": 10,
         "MockQuotaLimiter2": 20,
     }
+    
+
+def test_build_referenced_docs():
+    """Test build_referenced_docs."""
+    rag_chunks = [
+        RagChunk("bla", "url_1", "title_1"),
+        RagChunk("bla", "url_2", "title_2"),
+        RagChunk("bla", "url_1", "title_1"),  # duplicate
+    ]
+
+    assert ols.build_referenced_docs(rag_chunks) == [
+        {"doc_title": "title_1", "doc_url": "url_1"},
+        {"doc_title": "title_2", "doc_url": "url_2"},
+    ]

--- a/tests/unit/app/endpoints/test_streaming_ols.py
+++ b/tests/unit/app/endpoints/test_streaming_ols.py
@@ -10,7 +10,6 @@ from ols import config, constants
 config.ols_config.authentication_config.module = "k8s"
 
 from ols.app.endpoints.streaming_ols import (  # noqa:E402
-    build_referenced_docs,
     build_yield_item,
     format_stream_data,
     generic_llm_error,
@@ -166,17 +165,3 @@ def test_stream_end_event():
             "available_quotas": {"limiter1": 10, "limiter2": 20},
         }
     )
-
-
-def test_build_referenced_docs():
-    """Test build_referenced_docs."""
-    rag_chunks = [
-        RagChunk("bla", "url_1", "title_1"),
-        RagChunk("bla", "url_2", "title_2"),
-        RagChunk("bla", "url_1", "title_1"),  # duplicate
-    ]
-
-    assert build_referenced_docs(rag_chunks) == [
-        {"doc_title": "title_1", "doc_url": "url_1"},
-        {"doc_title": "title_2", "doc_url": "url_2"},
-    ]


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
As part of integrating road-core/service RAG and RHDH Lightspeed, we need to store the RAG data along with the AI Response content and attachments, so that they can be retrieved.

The `reference_documents` are saved in `AIMessage` property `additional_kwargs`. See below for a response from the API.

As to why it is stored under `additional_kwargs`?  Refer to the property [description](https://github.com/langchain-ai/langchain/blob/4071670f562effb72fe836a9cd1e01ba8dc371c6/libs/core/langchain_core/messages/base.py#L29-L34) which suggests `Reserved for additional payload data associated with the message.`

I have also updated the unit test with mock rag data to ensure it is working as expected.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/RHDHPAI-145

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
The unit test has been updated with a mock rag data and assert that the function is working as expected.

I have also manually tested both the `/query` and `/streaming_query` endpoints which call the `store_conversation_history` function

Here are the outputs from the `/conversations/{id}` to fetch the stored conversations which now include the RAG data

#### Conversation saved via `/streaming_query` and fetched by `/conversations/{id}`
```
{
    "chat_history": [
        {
            "content": "What are the benefits of Red Hat Developer Hub?",
            "additional_kwargs": {},
            "response_metadata": {
                "created_at": 1749592193.225523
            },
            "type": "human",
            "name": null,
            "id": null
        },
        {
            "content": "Red Hat Developer Hub offers several benefits, including:\n\n* Simplified and accelerated software delivery through a customizable web-based interface that centralizes access to key development resources.\n* Improved operational efficiency by removing manual handoffs and centralizing key development workflows, which increases return on engineering investment.\n* Faster onboarding for developers, who can use learning paths, software templates, and software catalog to deploy compliant services within minutes.\n* Reduced cognitive load for developers, as they can find tools, documentation, and deployment environments in one place.\n* Self-service workflows for developers, who can create applications or environments on demand without raising tickets or waiting for approvals.\n* Built-in standards for developers, who can use preconfigured templates that enforce secure, compliant workflows without requiring manual setup.\n* Cross-team visibility for developers, who can discover shared service catalogs and documentation to improve reuse and reduce duplication.\n* Higher productivity for developers, as they can spend more time building features and less time configuring infrastructure or resolving toolchain inconsistencies.\n\nAdditionally, Red Hat Developer Hub provides a centralized dashboard for accessing development tools, CI/CD pipelines, APIs, monitoring tools, and documentation from a single interface. It also supports learning paths, role-based access control, and 24x7 support.",
            "additional_kwargs": {
                "reference_documents": [
                    {
                        "doc_title": "About Red Hat Developer Hub",
                        "doc_url": "https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/about_red_hat_developer_hub/index"
                    },
                    {
                        "doc_title": "Adoption Insights in Red Hat Developer Hub",
                        "doc_url": "https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/adoption_insights_in_red_hat_developer_hub/index"
                    }
                ]
            },
            "response_metadata": {
                "created_at": 1749592205.5320199,
                "provider": "team_cluster",
                "model": "granite-31-8b-lab-v1-140-version-1"
            },
            "type": "ai",
            "name": null,
            "id": null
        }
    ]
}
```

#### Conversation saved via `/query` and fetched by `/conversations/{id}`
```
{
    "chat_history": [
        {
            "content": "Can ABC Limited use Red Hat Developer Hub? What are the benefits of RHDH? Can RHDH be installed on OCP and what kind of plugins can be installed?\n\n\n```\nABC Limited uses OpenShift Container Platform for their orchestration needs.\n```\n\n\nFor reference, here is the full resource YAML:\n```yaml\nkind: Pod\n metadata:\n name:    private-reg\n```\n\n\nFor reference, here is the full resource YAML:\n```yaml\nfoo: bar\n```",
            "additional_kwargs": {},
            "response_metadata": {
                "created_at": 1749592261.6439521
            },
            "type": "human",
            "name": null,
            "id": null
        },
        {
            "content": "ABC Limited can use Red Hat Developer Hub (RHDH) as it is a distribution of Kubernetes and can be integrated with OpenShift Container Platform (OCP). The benefits of RHDH include operational efficiency, curated platforms, central configuration, governance at scale, faster onboarding, reduced cognitive load, self-service workflows, built-in standards, cross-team visibility, and higher productivity.\n\nRHDH can be installed on OCP and supports various plugins. Static plugins are integrated into the core of the RHDH application, while dynamic plugins can be sideloaded into your Developer Hub instance without the need to recompile your code or rebuild the container. Dynamic plugins boost modularity and scalability by enabling more flexible and efficient functionality loading, significantly enhancing the developer experience and customization of your RHDH instance.\n\nHowever, it is important to note that Developer Preview features, such as RHDH Local, are not supported by Red Hat in any way and are not functionally complete or production-ready. They provide early access to functionality in advance of possible inclusion in a Red Hat product offering and are subject to change or removal at any time.",
            "additional_kwargs": {
                "reference_documents": [
                    {
                        "doc_title": "About Red Hat Developer Hub",
                        "doc_url": "https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/about_red_hat_developer_hub/index"
                    },
                    {
                        "doc_title": "Red Hat Developer Hub release notes",
                        "doc_url": "https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/red_hat_developer_hub_release_notes/index"
                    },
                    {
                        "doc_title": "Introduction to plugins",
                        "doc_url": "https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/introduction_to_plugins/index"
                    }
                ]
            },
            "response_metadata": {
                "created_at": 1749592271.8059158
            },
            "type": "ai",
            "name": null,
            "id": null
        }
    ]
}
```