### PR TITLE
add RETURNING clause to delete conversation query in postgres_cache

### DIFF
--- a/ols/src/cache/postgres_cache.py
+++ b/ols/src/cache/postgres_cache.py
@@ -82,6 +82,7 @@ class PostgresCache(Cache):
     DELETE_SINGLE_CONVERSATION_STATEMENT = """
         DELETE FROM cache
          WHERE user_id=%s AND conversation_id=%s
+         RETURNING conversation_id
         """
 
     LIST_CONVERSATIONS_STATEMENT = """

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -497,6 +497,25 @@ def test_delete_operation():
     mock_cursor.fetchone.assert_called_once()
 
 
+def test_delete_operation_raises_if_no_returning():
+    """Test the Cache.delete operation when delete query without RETURNING clause."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = psycopg2.DatabaseError("no results to fetch")
+
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.return_value.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
+
+        config = PostgresConfig()
+        cache = PostgresCache(config)
+
+        with pytest.raises(Exception) as exc_info:
+            cache.delete(user_id, conversation_id)
+
+    assert "no results to fetch" in str(exc_info.value)
+
+
 def test_delete_operation_not_found():
     """Test the Cache.delete operation when the conversation is not found."""
     # Mock the database cursor behavior to simulate no row found


### PR DESCRIPTION
## Description


This PR fixes a bug where an Excpetion was raised due to calling cursor.fetchone() after a DELETE SQL statement that did not return any results.

Now the DELETE statement was updated to include a RETURNING clause:

```sql
 DELETE FROM cache 
 WHERE user_id=%s AND conversation_id=%s
 RETURNING conversation_id
```         
This ensures the query returns a result row if a conversation was deleted, making it safe to call `cursor.fetchone()`.


<!--- Describe your changes in detail -->

## Type of change

- [x] Bug fix


## Related Tickets & Documents

- Closes # https://github.com/road-core/service/issues/641

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

To test this change:

1. Use postgres type for conversation_cache.
  ```yaml
  conversation_cache:
    type: postgres
    postgres:
        host: localhost
        port: 5432
        dbname: postgres
        user: postgres
        password_path: postgres_password.txt
```
2. Create a conversation
3. Delete the newly created conversation using DELETE /conversations/<conversation_id> endpoint
4. Should not see any errors/exceptions in the server logs.

----


**without this fix:**

![image](https://github.com/user-attachments/assets/4b4686d5-54ea-496b-aa3e-2f4d7eba342f)


**With this fix:**

![image](https://github.com/user-attachments/assets/fdc0f255-d29d-40e7-a32f-eeed27596280)

